### PR TITLE
feat(backend): update sending confirmation to user

### DIFF
--- a/apps/api/prisma/migrations/20260203161913_add_log_enum/migration.sql
+++ b/apps/api/prisma/migrations/20260203161913_add_log_enum/migration.sql
@@ -1,0 +1,2 @@
+-- AlterEnum
+ALTER TYPE "logs_action_type" ADD VALUE 'resend_email_confirmation';

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -47,6 +47,7 @@ enum LogsActionType {
   signin
   signup
   signout
+  resend_email_confirmation
 
   @@map("logs_action_type")
 }

--- a/apps/api/src/app/auth/auth.controller.ts
+++ b/apps/api/src/app/auth/auth.controller.ts
@@ -60,11 +60,15 @@ export class AuthController {
     return this.authService.signInWithOAuth(input);
   }
 
-  @Post('resend-signup')
+  @Post('resend-otp')
   @ApiOperation({ summary: 'Resend sign-up confirmation email' })
   @ApiResponse({ status: 200, type: AsyncReturnDto })
-  async resendSignUp(@Body() input: ResendSignUpDto) {
-    return this.authService.resendEmailSignUpConfirmation(input);
+  async resendSignUp(
+    @Body() input: ResendSignUpDto,
+    @Ip() ipAddress: string,
+    @Headers('user-agent') userAgent: string
+  ) {
+    return this.authService.resendEmailSignUpConfirmation(input, ipAddress, userAgent);
   }
 
   @Post('resend-change-email')

--- a/apps/api/src/app/auth/auth.service.ts
+++ b/apps/api/src/app/auth/auth.service.ts
@@ -14,6 +14,7 @@ import { UtilsService } from '../../utils/utils.service';
 @Injectable()
 export class AuthService {
   private supabase: SupabaseClient;
+  private supabaseAdmin: SupabaseClient;
 
   constructor(
     private readonly prisma: PrismaService,
@@ -21,12 +22,19 @@ export class AuthService {
   ) {
     const supabaseUrl = process.env.SUPABASE_URL;
     const supabaseKey = process.env.SUPABASE_KEY;
+    const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
 
-    if (supabaseUrl && supabaseKey) {
-      this.supabase = createClient(supabaseUrl, supabaseKey);
-    } else {
+    if (!supabaseUrl || !supabaseKey || !serviceRoleKey) {
       throw new Error(RETURN_MESSAGES.FAILURE.SUPABASE_CREDENTIALS_NOT_FOUND);
     }
+
+    this.supabase = createClient(supabaseUrl, supabaseKey);
+    this.supabaseAdmin = createClient(supabaseUrl, serviceRoleKey, {
+      auth: {
+        autoRefreshToken: false,
+        persistSession: false,
+      },
+    });
   }
 
   async signUpWithEmailPassword(input: SignUpInputInterface): Promise<AsyncReturn> {
@@ -264,43 +272,173 @@ export class AuthService {
     }
   }
 
-  async resendEmailSignUpConfirmation(input: ResendEmailSignUpConfirmation): Promise<AsyncReturn> {
+  /**
+   * Flow:
+   * 1. check if request > 3 times in a day from the same ip or email
+   * 2. if true return 429 else continue
+   * 3. check if request duration < 60s from the last request
+   * 4. if true return 429 else continue
+   * 5. check if user exist in users db
+   * 6. if not exist return error else continue
+   * 7. check if user is already confirmed
+   * 8. if confirmed return error else send confirmation email
+   * 9. save the activity to logs
+   * */ 
+  async resendEmailSignUpConfirmation(input: ResendEmailSignUpConfirmation, ipAddress: string, userAgent: string): Promise<AsyncReturnDto> {
     try {
+      const MAX_ATTEMPTS_PER_DAY = 3;
+      const MIN_INTERVAL_SECONDS = 60;
+
+      const todayStart = new Date();
+      todayStart.setUTCHours(0, 0, 0, 0);
+      const todayEnd = new Date();
+      todayEnd.setUTCHours(23, 59, 59, 999);
+
+      // Count resend attempts today by email and IP
+      const attemptsTodayByEmail = await this.prisma.db.logs.count({
+        where: {
+          actionType: LogsActionType.resend_email_confirmation,
+          metadata: { path: ['email'], equals: input.email },
+          createdAt: { gte: todayStart, lte: todayEnd },
+        },
+      });
+
+      const attemptsTodayByIp = await this.prisma.db.logs.count({
+        where: {
+          actionType: LogsActionType.resend_email_confirmation,
+          ipAddress,
+          createdAt: { gte: todayStart, lte: todayEnd },
+        },
+      });
+
+      if (attemptsTodayByEmail >= MAX_ATTEMPTS_PER_DAY || attemptsTodayByIp >= MAX_ATTEMPTS_PER_DAY) {
+        await this.prisma.db.logs.create({
+          data: {
+            actionType: LogsActionType.resend_email_confirmation,
+            targetId: "",
+            details: RETURN_MESSAGES.FAILURE.TOO_MANY_REQUESTS,
+            metadata: { email: input.email },
+            ipAddress,
+            userAgent,
+            createdById: null
+          }
+        });
+
+        return {
+          status: AsyncStatus.Error,
+          statusCode: 429,
+          message: RETURN_MESSAGES.FAILURE.TOO_MANY_REQUESTS,
+          data: null,
+        };
+      }
+
+      // Check last attempt time
+      const lastAttempt = await this.prisma.db.logs.findFirst({
+        where: {
+          actionType: LogsActionType.resend_email_confirmation,
+          metadata: { path: ['email'], equals: input.email },
+        },
+        orderBy: { createdAt: 'desc' },
+      });
+
+      if (lastAttempt) {
+        const secondsSinceLast = (Date.now() - lastAttempt.createdAt.getTime()) / 1000;
+        if (secondsSinceLast < MIN_INTERVAL_SECONDS) {
+          return {
+            status: AsyncStatus.Error,
+            statusCode: 429,
+            message: `Please wait ${Math.ceil(MIN_INTERVAL_SECONDS - secondsSinceLast)} seconds before trying again.`,
+            data: null,
+          };
+        }
+      }
+
+      // Check user in DB
+      const user = await this.prisma.db.user.findUnique({
+        where: { email: input.email },
+      });
+
+      if (!user) {
+        return {
+          status: AsyncStatus.Error,
+          statusCode: 404,
+          message: RETURN_MESSAGES.FAILURE.USER_NOT_FOUND,
+          data: input,
+        };
+      }
+
+      const { data: userData, error: fetchError } = await this.supabaseAdmin.auth.admin.getUserById(user.id);
+      
+      if (fetchError || !userData) {
+        return {
+          status: AsyncStatus.Error,
+          statusCode: 404,
+          message: RETURN_MESSAGES.FAILURE.USER_NOT_FOUND,
+          data: fetchError,
+        };
+      }
+
+      // Check if email is already confirmed
+      if (userData.user.email_confirmed_at) {
+        return {
+          status: AsyncStatus.Error,
+          statusCode: 400,
+          message: RETURN_MESSAGES.FAILURE.EMAIL_ALREADY_CONFIRMED,
+          data: null,
+        };
+      }
+
+      // Resend email via Supabase
       const { data, error } = await this.supabase.auth.resend({
         type: 'signup',
         email: input.email,
         ...(input.options
-          ? { 
-              options: { 
-                emailRedirectTo: 
-                  input.options.emailRedirectTo || 
-                  RETURN_MESSAGES.LINKS.DEFAULT_REDIRECT_URL
-              } 
+          ? {
+              options: {
+                emailRedirectTo: input.options.emailRedirectTo || RETURN_MESSAGES.LINKS.DEFAULT_REDIRECT_URL,
+              },
             }
           : {}),
-      });  
+      });
+
+      // Log the attempt
+      await this.prisma.db.logs.create({
+        data: {
+          actionType: LogsActionType.resend_email_confirmation,
+          targetId: user.id,
+          details: error
+            ? RETURN_MESSAGES.FAILURE.INTERNAL_SERVER_ERROR
+            : RETURN_MESSAGES.SUCCESS.EMAIL_SENT,
+          metadata: { email: input.email },
+          ipAddress,
+          userAgent,
+          createdById: user.id,
+        },
+      });
 
       if (error) {
-        console.error(error);
         return {
           status: AsyncStatus.Error,
+          statusCode: 500,
           message: RETURN_MESSAGES.FAILURE.INTERNAL_SERVER_ERROR,
-          data: error
-        }
+          data: error,
+        };
       }
 
       return {
         status: AsyncStatus.Success,
+        statusCode: 200,
         message: RETURN_MESSAGES.SUCCESS.EMAIL_SENT,
-        data: data || true
-      }
+        data: data || true,
+      };
     } catch (error) {
       console.error(error);
       return {
         status: AsyncStatus.Error,
+        statusCode: 500,
         message: RETURN_MESSAGES.FAILURE.INTERNAL_SERVER_ERROR,
-        data: error
-      }
+        data: error,
+      };
     }
   }
 

--- a/lib/models/src/lib/constants.ts
+++ b/lib/models/src/lib/constants.ts
@@ -40,6 +40,8 @@ export const RETURN_MESSAGES = {
     SIGNIN_ATTEMPT_EMAIL_NOT_VERIFIED: 'Failed signin attempt: Email address is not verified',
     SIGNIN_ATTEMPT_TOO_MANY_ATTEMPTS: 'Too many failed login attempts. Try again later.',
     SIGNIN_ATTEMPT_USER_NOT_FOUND: 'Failed signin attempt: User not found',
+    EMAIL_ALREADY_CONFIRMED: 'Email address is already confirmed',
+    TOO_MANY_REQUESTS: 'Too many requests',
   },
   LINKS: {
     DEFAULT_REDIRECT_URL: 'https://google.com',


### PR DESCRIPTION
# Ticket: https://github.com/Angular-PH-X-GuroKonekt-PH/gurokonekt-monorepo/issues/57

Changes: 
- sending confirmation to user base on provided email with restriction base on the number or request in the current date
- it also limit sending confirmation link to emails that is already confirmed

Note:
I use service role key for supabase admin methods, I already update the notion testing env credentials