### PR TITLE
feat(be): update search endpoint for the mentee

### DIFF
--- a/apps/api/prisma/migrations/20260313175541_add_mentor_profile_title/migration.sql
+++ b/apps/api/prisma/migrations/20260313175541_add_mentor_profile_title/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "mentor_profiles" ADD COLUMN     "title" TEXT;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -151,6 +151,7 @@ model MenteeProfile {
 model MentorProfile {
   id                String    @id @default(uuid())
   userId            String    @unique @map("user_id")
+  title             String?
   areasOfExpertise  String[]  @map("areas_of_expertise")
   yearsOfExperience Int?      @map("years_of_experience")
   linkedInUrl       String?   @map("linkedin_url")

--- a/apps/api/src/app/search/search.controller.ts
+++ b/apps/api/src/app/search/search.controller.ts
@@ -2,6 +2,7 @@ import {
   Controller,
   ForbiddenException,
   Get,
+  Param,
   Query,
   Req,
   UseGuards,
@@ -9,6 +10,7 @@ import {
 import {
   ApiBearerAuth,
   ApiOperation,
+  ApiParam,
   ApiQuery,
   ApiResponse,
   ApiTags,
@@ -17,6 +19,7 @@ import { Request } from 'express';
 import { JwtGuardGuard } from '../jwt-guard/jwt-guard.guard';
 import { SearchService } from './search.service';
 import {
+  DaysInWeek,
   ResponseDto,
   SearchMentorDto,
   SearchSortBy,
@@ -29,6 +32,23 @@ import {
 @Controller('search')
 export class SearchController {
   constructor(private readonly searchService: SearchService) {}
+
+  // ====================================================
+  // GET /api/search – Mentor Search
+  // ====================================================
+
+  // ====================================================
+  // GET /api/search/mentor/:mentorId – Mentor Profile Detail
+  // ====================================================
+
+  @Get('mentor/:mentorId')
+  @ApiOperation({ summary: 'Get full mentor profile by mentor user ID' })
+  @ApiParam({ name: 'mentorId', type: String })
+  @ApiResponse({ status: 200, description: 'Mentor profile retrieved successfully', type: ResponseDto })
+  @ApiResponse({ status: 404, description: 'Mentor not found or not available' })
+  async getMentorProfile(@Param('mentorId') mentorId: string) {
+    return this.searchService.getMentorProfileById(mentorId);
+  }
 
   // ====================================================
   // GET /api/search – Mentor Search
@@ -49,7 +69,9 @@ Returns a paginated list of approved, active mentors.
 - \`skills\` — comma-separated skills (e.g. \`TypeScript,Node.js\`)
 - \`expertise\` — comma-separated expertise areas
 - \`minSessionRate\` / \`maxSessionRate\` — session rate range
-- \`minYearsExperience\` — minimum years of experience
+- \`minYearsExperience\` / \`maxYearsExperience\` — years of experience range
+- \`language\` — case-insensitive language filter
+- \`availabilityDay\` — filter by day of availability
 - \`sortBy\` — newest | sessionRate | yearsExperience | name
 - \`sortOrder\` — asc | desc
 - \`page\` / \`limit\` — pagination (limit max 50)
@@ -61,6 +83,9 @@ Returns a paginated list of approved, active mentors.
   @ApiQuery({ name: 'minSessionRate', required: false, type: Number })
   @ApiQuery({ name: 'maxSessionRate', required: false, type: Number })
   @ApiQuery({ name: 'minYearsExperience', required: false, type: Number })
+  @ApiQuery({ name: 'maxYearsExperience', required: false, type: Number })
+  @ApiQuery({ name: 'language', required: false, type: String })
+  @ApiQuery({ name: 'availabilityDay', required: false, enum: DaysInWeek })
   @ApiQuery({ name: 'sortBy', required: false, enum: SearchSortBy })
   @ApiQuery({ name: 'sortOrder', required: false, enum: SearchSortOrder })
   @ApiQuery({ name: 'page', required: false, type: Number })

--- a/apps/api/src/app/search/search.service.ts
+++ b/apps/api/src/app/search/search.service.ts
@@ -2,6 +2,8 @@ import { Injectable, Logger } from '@nestjs/common';
 import { PrismaService } from '../prisma/prisma.service';
 import {
   API_RESPONSE,
+  DaysInWeek,
+  MentorProfileDetailInterface,
   MentorSearchItemInterface,
   MentorSearchResultInterface,
   ResponseDto,
@@ -60,8 +62,9 @@ export class SearchService {
         });
 
         const sorted = this.sortInMemory(all as unknown as MentorSearchItemInterface[], sortBy, sortOrder);
-        total = sorted.length;
-        results = sorted.slice((page - 1) * limit, page * limit);
+        const filtered = this.filterByAvailabilityDay(sorted, dto.availabilityDay);
+        total = filtered.length;
+        results = filtered.slice((page - 1) * limit, page * limit);
       } else {
         const orderBy = this.buildOrderBy(sortBy, sortOrder);
         [total, results] = await Promise.all([
@@ -74,6 +77,8 @@ export class SearchService {
             take: limit,
           }) as unknown as Promise<MentorSearchItemInterface[]>,
         ]);
+        results = this.filterByAvailabilityDay(results, dto.availabilityDay);
+        total = results.length;
       }
 
       return {
@@ -126,6 +131,11 @@ export class SearchService {
       { isMentorApproved: true },
       { isMentorProfileComplete: true },
     ];
+
+    // Language filter (case-insensitive)
+    if (dto.language) {
+      topLevelAnd.push({ language: { equals: dto.language, mode: 'insensitive' } });
+    }
 
     // Name filter (partial, case-insensitive)
     if (dto.name?.trim()) {
@@ -183,9 +193,14 @@ export class SearchService {
       });
     }
 
-    // Minimum years of experience 
-    if (dto.minYearsExperience !== undefined) {
-      profileConditions.push({ yearsOfExperience: { gte: dto.minYearsExperience } });
+    // Years of experience range
+    if (dto.minYearsExperience !== undefined || dto.maxYearsExperience !== undefined) {
+      profileConditions.push({
+        yearsOfExperience: {
+          ...(dto.minYearsExperience !== undefined ? { gte: dto.minYearsExperience } : {}),
+          ...(dto.maxYearsExperience !== undefined ? { lte: dto.maxYearsExperience } : {}),
+        },
+      });
     }
 
     // Attach profile conditions. Always require at least one mentorProfile record.
@@ -248,5 +263,122 @@ export class SearchService {
 
       return 0;
     });
+  }
+
+  // ====================================================
+  // PRIVATE – AVAILABILITY DAY POST-FILTER
+  // ====================================================
+
+  private filterByAvailabilityDay(
+    mentors: MentorSearchItemInterface[],
+    day: DaysInWeek | undefined,
+  ): MentorSearchItemInterface[] {
+    if (!day) return mentors;
+
+    return mentors.filter((mentor) => {
+      const availability = mentor.mentorProfiles[0]?.availability;
+      if (!availability || !Array.isArray(availability)) return false;
+      return (availability as { day: string }[]).some(
+        (slot) => slot.day?.toLowerCase() === day.toLowerCase(),
+      );
+    });
+  }
+
+  // ====================================================
+  // GET MENTOR PROFILE BY ID
+  // ====================================================
+
+  async getMentorProfileById(
+    mentorId: string,
+  ): Promise<ResponseDto<MentorProfileDetailInterface | null>> {
+    try {
+      const profile = await this.prisma.db.mentorProfile.findUnique({
+        where: { userId: mentorId },
+        select: {
+          id: true,
+          title: true,
+          bio: true,
+          areasOfExpertise: true,
+          yearsOfExperience: true,
+          skills: true,
+          sessionRate: true,
+          availability: true,
+          linkedInUrl: true,
+          updatedAt: true,
+          user: {
+            select: {
+              id: true,
+              firstName: true,
+              middleName: true,
+              lastName: true,
+              suffix: true,
+              language: true,
+              country: true,
+              timezone: true,
+              status: true,
+              isMentorApproved: true,
+              isMentorProfileComplete: true,
+              avatarAttachments: {
+                select: { publicUrl: true, fileName: true },
+              },
+            },
+          },
+        },
+      });
+
+      if (
+        !profile ||
+        profile.user.status !== 'active' ||
+        !profile.user.isMentorApproved ||
+        !profile.user.isMentorProfileComplete
+      ) {
+        return {
+          status: ResponseStatus.Error,
+          statusCode: API_RESPONSE.ERROR.USER_NOT_FOUND.code,
+          message: 'Mentor not found or not available',
+          data: null,
+        };
+      }
+
+      const { user } = profile;
+      const result: MentorProfileDetailInterface = {
+        id: profile.id,
+        title: profile.title,
+        bio: profile.bio,
+        areasOfExpertise: profile.areasOfExpertise,
+        yearsOfExperience: profile.yearsOfExperience,
+        skills: profile.skills,
+        sessionRate: profile.sessionRate,
+        availability: profile.availability,
+        linkedInUrl: profile.linkedInUrl,
+        updatedAt: profile.updatedAt,
+        user: {
+          id: user.id,
+          firstName: user.firstName,
+          middleName: user.middleName,
+          lastName: user.lastName,
+          suffix: user.suffix,
+          language: user.language,
+          country: user.country,
+          timezone: user.timezone,
+          avatarAttachments: user.avatarAttachments,
+        },
+      };
+
+      return {
+        status: ResponseStatus.Success,
+        statusCode: API_RESPONSE.SUCCESS.GET_BOOKINGS.code,
+        message: 'Mentor profile retrieved successfully',
+        data: result,
+      };
+    } catch (error) {
+      this.logger.error(error.message, error.stack);
+      return {
+        status: ResponseStatus.Error,
+        statusCode: API_RESPONSE.ERROR.INTERNAL_SERVER_ERROR.code,
+        message: API_RESPONSE.ERROR.INTERNAL_SERVER_ERROR.message,
+        data: null,
+      };
+    }
   }
 }

--- a/lib/models/src/lib/dto/constants/select-fields.const.ts
+++ b/lib/models/src/lib/dto/constants/select-fields.const.ts
@@ -27,6 +27,7 @@ export class SelectFields {
   static getMentorProfileSelect() {
     return {
       id: true,
+      title: true,
       areasOfExpertise: true,
       yearsOfExperience: true,
       linkedInUrl: true,
@@ -100,6 +101,7 @@ export class SelectFields {
       mentorProfiles: {
         select: {
           id: true,
+          title: true,
           areasOfExpertise: true,
           yearsOfExperience: true,
           bio: true,

--- a/lib/models/src/lib/dto/search/search-mentor.dto.ts
+++ b/lib/models/src/lib/dto/search/search-mentor.dto.ts
@@ -9,6 +9,7 @@ import {
   Max,
   Min,
 } from 'class-validator';
+import { DaysInWeek } from '../../interfaces/user/user.model';
 
 export enum SearchSortBy {
   NEWEST = 'newest',
@@ -76,6 +77,33 @@ export class SearchMentorDto {
   @IsInt()
   @Min(0)
   minYearsExperience?: number;
+
+  @ApiPropertyOptional({
+    description: 'Maximum years of experience',
+    example: 10,
+  })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(0)
+  maxYearsExperience?: number;
+
+  @ApiPropertyOptional({
+    description: 'Filter by mentor language (case-insensitive)',
+    example: 'English',
+  })
+  @IsOptional()
+  @IsString()
+  language?: string;
+
+  @ApiPropertyOptional({
+    enum: DaysInWeek,
+    description: 'Filter by availability day',
+    example: DaysInWeek.Monday,
+  })
+  @IsOptional()
+  @IsEnum(DaysInWeek)
+  availabilityDay?: DaysInWeek;
 
   @ApiPropertyOptional({
     description: 'Page number (1-based)',

--- a/lib/models/src/lib/interfaces/search/search.model.ts
+++ b/lib/models/src/lib/interfaces/search/search.model.ts
@@ -15,8 +15,9 @@ export interface MentorSearchItemInterface {
   mentorProfiles: MentorProfileSearch[];
 }
 
-export interface MentorProfileSearch { 
+export interface MentorProfileSearch {
   id: string;
+  title: string | null;
   areasOfExpertise: string[];
   yearsOfExperience: number | null;
   bio: string | null;
@@ -25,6 +26,30 @@ export interface MentorProfileSearch {
   availability: unknown;
   linkedInUrl: string | null;
   updatedAt: Date;
+}
+
+export interface MentorProfileDetailInterface {
+  id: string;
+  title: string | null;
+  bio: string | null;
+  areasOfExpertise: string[];
+  yearsOfExperience: number | null;
+  skills: string[];
+  sessionRate: number | null;
+  availability: unknown;
+  linkedInUrl: string | null;
+  updatedAt: Date;
+  user: {
+    id: string;
+    firstName: string;
+    middleName: string | null;
+    lastName: string;
+    suffix: string | null;
+    language: string | null;
+    country: string | null;
+    timezone: string | null;
+    avatarAttachments: { publicUrl: string; fileName: string }[];
+  };
 }
 
 export interface MenttorAttachmentSearch {


### PR DESCRIPTION
# Tickets: #119 & #116 

## Changes                                                                                                                   
                                                                                                                                   
  Schema                                                                                                                             
  - Added title String? to MentorProfile + migration                                                                                 

  Search (GET /search)
  - New filters: language (case-insensitive, DB-level), maxYearsExperience (upper bound on existing range), availabilityDay
  (post-query filter against availability JSON)
  - Search results now include title from mentor profile

  New endpoint (GET /search/mentor/:mentorId)
  - Returns full mentor profile for a given mentor user ID
  - Guards: JWT required; returns 404 if mentor is not active, isMentorApproved, or isMentorProfileComplete

  Models (@gurokonekt/models)
  - MentorProfileSearch — added title
  - SearchMentorDto — added language, availabilityDay, maxYearsExperience
  - New MentorProfileDetailInterface for the profile detail response
