### PR TITLE
Feat be mentor bookings notification

### DIFF
--- a/apps/api/prisma/migrations/20260313175541_add_mentor_profile_title/migration.sql
+++ b/apps/api/prisma/migrations/20260313175541_add_mentor_profile_title/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "mentor_profiles" ADD COLUMN     "title" TEXT;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -151,6 +151,7 @@ model MenteeProfile {
 model MentorProfile {
   id                String    @id @default(uuid())
   userId            String    @unique @map("user_id")
+  title             String?
   areasOfExpertise  String[]  @map("areas_of_expertise")
   yearsOfExperience Int?      @map("years_of_experience")
   linkedInUrl       String?   @map("linkedin_url")

--- a/apps/api/src/app/booking/booking.controller.ts
+++ b/apps/api/src/app/booking/booking.controller.ts
@@ -6,6 +6,7 @@ import {
   Param,
   Patch,
   Post,
+  Query,
   Req,
   UseGuards,
 } from '@nestjs/common';
@@ -13,6 +14,7 @@ import {
   ApiBearerAuth,
   ApiOperation,
   ApiParam,
+  ApiQuery,
   ApiResponse,
   ApiTags,
 } from '@nestjs/swagger';
@@ -20,7 +22,10 @@ import { Request } from 'express';
 import { JwtGuardGuard } from '../jwt-guard/jwt-guard.guard';
 import { BookingService } from './booking.service';
 import {
+  ApproveBookingDto,
+  BookingStatus,
   CreateBookingDto,
+  MentorBookingsQueryDto,
   ResponseDto,
   UpdateBookingDto,
 } from '@gurokonekt/models';
@@ -59,6 +64,23 @@ export class BookingController {
   }
 
   // ====================================================
+  // GET - Get Mentor's Own Bookings (from JWT)
+  // NOTE: declared before :id and user/:userId to prevent route conflict
+  // ====================================================
+
+  @Get('mentor')
+  @ApiOperation({ summary: 'Get bookings for the authenticated mentor, with optional status filter' })
+  @ApiQuery({ name: 'status', required: false, enum: BookingStatus, description: 'Filter by booking status' })
+  @ApiResponse({ status: 200, description: 'Bookings retrieved successfully', type: ResponseDto })
+  @ApiResponse({ status: 403, description: 'Access denied' })
+  async findMentorBookings(
+    @Query() query: MentorBookingsQueryDto,
+    @Req() req: Request & { user: { id: string } },
+  ) {
+    return this.bookingService.findMentorBookings(req.user.id, req.user.id, query);
+  }
+
+  // ====================================================
   // GET - Get Bookings By User ID
   // NOTE: declared before :id to prevent route conflict
   // ====================================================
@@ -90,6 +112,62 @@ export class BookingController {
     @Req() req: Request & { user: { id: string } },
   ) {
     return this.bookingService.findById(id, req.user.id);
+  }
+
+  // ====================================================
+  // PATCH - Approve Booking (mentor only, PENDING → APPROVED)
+  // NOTE: declared before :id to prevent route conflict
+  // ====================================================
+
+  @Patch(':id/approve')
+  @ApiOperation({ summary: 'Approve a pending booking (mentor only). Requires session link.' })
+  @ApiParam({ name: 'id', type: String, description: 'UUID of the booking', example: 'uuid-booking-id' })
+  @ApiResponse({ status: 200, description: 'Booking approved successfully', type: ResponseDto })
+  @ApiResponse({ status: 400, description: 'Invalid status transition' })
+  @ApiResponse({ status: 403, description: 'Access denied' })
+  @ApiResponse({ status: 404, description: 'Booking not found' })
+  async approveBooking(
+    @Param('id') id: string,
+    @Body() dto: ApproveBookingDto,
+    @Req() req: Request & { user: { id: string } },
+  ) {
+    return this.bookingService.approveBooking(id, req.user.id, dto);
+  }
+
+  // ====================================================
+  // PATCH - Reject Booking (mentor only, PENDING → REJECTED)
+  // ====================================================
+
+  @Patch(':id/reject')
+  @ApiOperation({ summary: 'Reject a pending booking (mentor only)' })
+  @ApiParam({ name: 'id', type: String, description: 'UUID of the booking', example: 'uuid-booking-id' })
+  @ApiResponse({ status: 200, description: 'Booking rejected successfully', type: ResponseDto })
+  @ApiResponse({ status: 400, description: 'Invalid status transition' })
+  @ApiResponse({ status: 403, description: 'Access denied' })
+  @ApiResponse({ status: 404, description: 'Booking not found' })
+  async rejectBooking(
+    @Param('id') id: string,
+    @Req() req: Request & { user: { id: string } },
+  ) {
+    return this.bookingService.rejectBooking(id, req.user.id);
+  }
+
+  // ====================================================
+  // PATCH - Complete Booking (mentor only, APPROVED → COMPLETED)
+  // ====================================================
+
+  @Patch(':id/complete')
+  @ApiOperation({ summary: 'Mark an approved booking as completed (mentor only, session must have already occurred)' })
+  @ApiParam({ name: 'id', type: String, description: 'UUID of the booking', example: 'uuid-booking-id' })
+  @ApiResponse({ status: 200, description: 'Session marked as completed', type: ResponseDto })
+  @ApiResponse({ status: 400, description: 'Invalid status transition or session has not yet occurred' })
+  @ApiResponse({ status: 403, description: 'Access denied' })
+  @ApiResponse({ status: 404, description: 'Booking not found' })
+  async completeBooking(
+    @Param('id') id: string,
+    @Req() req: Request & { user: { id: string } },
+  ) {
+    return this.bookingService.completeBooking(id, req.user.id);
   }
 
   // ====================================================

--- a/apps/api/src/app/booking/booking.module.ts
+++ b/apps/api/src/app/booking/booking.module.ts
@@ -1,5 +1,6 @@
 import { Module } from '@nestjs/common';
 import { PassportModule } from '@nestjs/passport';
+import { NotificationGateway } from '../gateway/notification-gateway.gateway';
 import { JwtGuardModule } from '../jwt-guard/jwt-guard.module';
 import { PrismaModule } from '../prisma/prisma.module';
 import { BookingController } from './booking.controller';
@@ -8,6 +9,6 @@ import { BookingService } from './booking.service';
 @Module({
   imports: [PrismaModule, JwtGuardModule, PassportModule],
   controllers: [BookingController],
-  providers: [BookingService],
+  providers: [BookingService, NotificationGateway],
 })
 export class BookingModule {}

--- a/apps/api/src/app/booking/booking.service.ts
+++ b/apps/api/src/app/booking/booking.service.ts
@@ -2,14 +2,23 @@ import { Injectable, Logger } from '@nestjs/common';
 import { PrismaService } from '../prisma/prisma.service';
 import {
   API_RESPONSE,
+  ApproveBookingDto,
   BookingInterface,
   BookingStatus,
   CreateBookingDto,
+  MentorBookingsQueryDto,
+  NotificationStatus,
+  NotificationType,
+  NotificationInterface,
   ResponseDto,
   ResponseStatus,
   UpdateBookingDto,
   UserRole,
 } from '@gurokonekt/models';
+import {
+  NOTIFICATION_EVENTS,
+  NotificationGateway,
+} from '../gateway/notification-gateway.gateway';
 
 /** Fields selected for mentor/mentee when returning a booking list entry. */
 const BOOKING_USER_SELECT = {
@@ -25,7 +34,10 @@ const BOOKING_USER_SELECT = {
 export class BookingService {
   private readonly logger = new Logger(BookingService.name);
 
-  constructor(private readonly prisma: PrismaService) {}
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly notificationGateway: NotificationGateway,
+  ) {}
 
   // ====================================================
   // CREATE
@@ -49,6 +61,14 @@ export class BookingService {
           mentee: { select: BOOKING_USER_SELECT },
         },
       });
+
+      await this.createNotification(
+        dto.mentorId,
+        'New Booking Request',
+        'You have received a new booking request from a mentee.',
+        NotificationType.BOOKING,
+        booking.id,
+      );
 
       return {
         status: ResponseStatus.Success,
@@ -330,8 +350,313 @@ export class BookingService {
   }
 
   // ====================================================
+  // GET MENTOR BOOKINGS
+  // ====================================================
+
+  async findMentorBookings(
+    mentorId: string,
+    authenticatedUserId: string,
+    query: MentorBookingsQueryDto,
+  ): Promise<ResponseDto<BookingInterface[]>> {
+    try {
+      const isAdmin = await this.checkIsAdmin(authenticatedUserId);
+
+      if (!isAdmin && mentorId !== authenticatedUserId) {
+        return {
+          status: ResponseStatus.Error,
+          statusCode: API_RESPONSE.ERROR.BOOKING_ACCESS_DENIED.code,
+          message: API_RESPONSE.ERROR.BOOKING_ACCESS_DENIED.message,
+          data: null,
+        };
+      }
+
+      const bookings = await this.prisma.db.booking.findMany({
+        where: {
+          mentorId,
+          isDeleted: false,
+          ...(query.status !== undefined && { status: query.status }),
+        },
+        orderBy: { sessionDateTime: 'asc' },
+        include: {
+          mentor: { select: BOOKING_USER_SELECT },
+          mentee: { select: BOOKING_USER_SELECT },
+        },
+      });
+
+      return {
+        status: ResponseStatus.Success,
+        statusCode: API_RESPONSE.SUCCESS.GET_MENTOR_BOOKINGS.code,
+        message: API_RESPONSE.SUCCESS.GET_MENTOR_BOOKINGS.message,
+        data: bookings as unknown as BookingInterface[],
+      };
+    } catch (error) {
+      this.logger.error(error.message, error.stack);
+      return {
+        status: ResponseStatus.Error,
+        statusCode: API_RESPONSE.ERROR.GET_MENTOR_BOOKINGS.code,
+        message: API_RESPONSE.ERROR.GET_MENTOR_BOOKINGS.message,
+        data: null,
+      };
+    }
+  }
+
+  // ====================================================
+  // APPROVE BOOKING
+  // ====================================================
+
+  async approveBooking(
+    id: string,
+    authenticatedUserId: string,
+    dto: ApproveBookingDto,
+  ): Promise<ResponseDto<BookingInterface>> {
+    try {
+      const existing = await this.prisma.db.booking.findUnique({ where: { id } });
+
+      if (!existing || existing.isDeleted) {
+        return {
+          status: ResponseStatus.Error,
+          statusCode: API_RESPONSE.ERROR.BOOKING_NOT_FOUND.code,
+          message: API_RESPONSE.ERROR.BOOKING_NOT_FOUND.message,
+          data: null,
+        };
+      }
+
+      if (existing.mentorId !== authenticatedUserId) {
+        return {
+          status: ResponseStatus.Error,
+          statusCode: API_RESPONSE.ERROR.BOOKING_ACCESS_DENIED.code,
+          message: API_RESPONSE.ERROR.BOOKING_ACCESS_DENIED.message,
+          data: null,
+        };
+      }
+
+      if (existing.status !== BookingStatus.PENDING) {
+        return {
+          status: ResponseStatus.Error,
+          statusCode: API_RESPONSE.ERROR.BOOKING_INVALID_TRANSITION.code,
+          message: API_RESPONSE.ERROR.BOOKING_INVALID_TRANSITION.message,
+          data: null,
+        };
+      }
+
+      const updated = await this.prisma.db.booking.update({
+        where: { id },
+        data: { status: BookingStatus.APPROVED, sessionLink: dto.sessionLink },
+        include: {
+          mentor: { select: BOOKING_USER_SELECT },
+          mentee: { select: BOOKING_USER_SELECT },
+        },
+      });
+
+      await this.createNotification(
+        existing.menteeId,
+        'Booking Approved',
+        'Your booking request has been approved by the mentor.',
+        NotificationType.BOOKING,
+        id,
+      );
+
+      return {
+        status: ResponseStatus.Success,
+        statusCode: API_RESPONSE.SUCCESS.APPROVE_BOOKING.code,
+        message: API_RESPONSE.SUCCESS.APPROVE_BOOKING.message,
+        data: updated as unknown as BookingInterface,
+      };
+    } catch (error) {
+      this.logger.error(error.message, error.stack);
+      return {
+        status: ResponseStatus.Error,
+        statusCode: API_RESPONSE.ERROR.APPROVE_BOOKING.code,
+        message: API_RESPONSE.ERROR.APPROVE_BOOKING.message,
+        data: null,
+      };
+    }
+  }
+
+  // ====================================================
+  // REJECT BOOKING
+  // ====================================================
+
+  async rejectBooking(
+    id: string,
+    authenticatedUserId: string,
+  ): Promise<ResponseDto<BookingInterface>> {
+    try {
+      const existing = await this.prisma.db.booking.findUnique({ where: { id } });
+
+      if (!existing || existing.isDeleted) {
+        return {
+          status: ResponseStatus.Error,
+          statusCode: API_RESPONSE.ERROR.BOOKING_NOT_FOUND.code,
+          message: API_RESPONSE.ERROR.BOOKING_NOT_FOUND.message,
+          data: null,
+        };
+      }
+
+      if (existing.mentorId !== authenticatedUserId) {
+        return {
+          status: ResponseStatus.Error,
+          statusCode: API_RESPONSE.ERROR.BOOKING_ACCESS_DENIED.code,
+          message: API_RESPONSE.ERROR.BOOKING_ACCESS_DENIED.message,
+          data: null,
+        };
+      }
+
+      if (existing.status !== BookingStatus.PENDING) {
+        return {
+          status: ResponseStatus.Error,
+          statusCode: API_RESPONSE.ERROR.BOOKING_INVALID_TRANSITION.code,
+          message: API_RESPONSE.ERROR.BOOKING_INVALID_TRANSITION.message,
+          data: null,
+        };
+      }
+
+      const updated = await this.prisma.db.booking.update({
+        where: { id },
+        data: { status: BookingStatus.REJECTED },
+        include: {
+          mentor: { select: BOOKING_USER_SELECT },
+          mentee: { select: BOOKING_USER_SELECT },
+        },
+      });
+
+      await this.createNotification(
+        existing.menteeId,
+        'Booking Rejected',
+        'Your booking request has been declined by the mentor.',
+        NotificationType.BOOKING,
+        id,
+      );
+
+      return {
+        status: ResponseStatus.Success,
+        statusCode: API_RESPONSE.SUCCESS.REJECT_BOOKING.code,
+        message: API_RESPONSE.SUCCESS.REJECT_BOOKING.message,
+        data: updated as unknown as BookingInterface,
+      };
+    } catch (error) {
+      this.logger.error(error.message, error.stack);
+      return {
+        status: ResponseStatus.Error,
+        statusCode: API_RESPONSE.ERROR.REJECT_BOOKING.code,
+        message: API_RESPONSE.ERROR.REJECT_BOOKING.message,
+        data: null,
+      };
+    }
+  }
+
+  // ====================================================
+  // COMPLETE BOOKING
+  // ====================================================
+
+  async completeBooking(
+    id: string,
+    authenticatedUserId: string,
+  ): Promise<ResponseDto<BookingInterface>> {
+    try {
+      const existing = await this.prisma.db.booking.findUnique({ where: { id } });
+
+      if (!existing || existing.isDeleted) {
+        return {
+          status: ResponseStatus.Error,
+          statusCode: API_RESPONSE.ERROR.BOOKING_NOT_FOUND.code,
+          message: API_RESPONSE.ERROR.BOOKING_NOT_FOUND.message,
+          data: null,
+        };
+      }
+
+      if (existing.mentorId !== authenticatedUserId) {
+        return {
+          status: ResponseStatus.Error,
+          statusCode: API_RESPONSE.ERROR.BOOKING_ACCESS_DENIED.code,
+          message: API_RESPONSE.ERROR.BOOKING_ACCESS_DENIED.message,
+          data: null,
+        };
+      }
+
+      if (existing.status !== BookingStatus.APPROVED) {
+        return {
+          status: ResponseStatus.Error,
+          statusCode: API_RESPONSE.ERROR.BOOKING_INVALID_TRANSITION.code,
+          message: API_RESPONSE.ERROR.BOOKING_INVALID_TRANSITION.message,
+          data: null,
+        };
+      }
+
+      if (existing.sessionDateTime > new Date()) {
+        return {
+          status: ResponseStatus.Error,
+          statusCode: API_RESPONSE.ERROR.BOOKING_INVALID_TRANSITION.code,
+          message: 'Session has not yet occurred',
+          data: null,
+        };
+      }
+
+      const updated = await this.prisma.db.booking.update({
+        where: { id },
+        data: { status: BookingStatus.COMPLETED },
+        include: {
+          mentor: { select: BOOKING_USER_SELECT },
+          mentee: { select: BOOKING_USER_SELECT },
+        },
+      });
+
+      await this.createNotification(
+        existing.menteeId,
+        'Session Completed',
+        'Your mentoring session has been marked as completed.',
+        NotificationType.SESSION,
+        id,
+      );
+
+      return {
+        status: ResponseStatus.Success,
+        statusCode: API_RESPONSE.SUCCESS.COMPLETE_BOOKING.code,
+        message: API_RESPONSE.SUCCESS.COMPLETE_BOOKING.message,
+        data: updated as unknown as BookingInterface,
+      };
+    } catch (error) {
+      this.logger.error(error.message, error.stack);
+      return {
+        status: ResponseStatus.Error,
+        statusCode: API_RESPONSE.ERROR.COMPLETE_BOOKING.code,
+        message: API_RESPONSE.ERROR.COMPLETE_BOOKING.message,
+        data: null,
+      };
+    }
+  }
+
+  // ====================================================
   // PRIVATE HELPERS
   // ====================================================
+
+  private async createNotification(
+    userId: string,
+    title: string,
+    message: string,
+    type: NotificationType,
+    referenceId?: string,
+  ): Promise<void> {
+    try {
+      const notification = await this.prisma.db.notification.create({
+        data: {
+          userId,
+          title,
+          message,
+          type,
+          status: NotificationStatus.UNREAD,
+          referenceId: referenceId ?? null,
+        },
+      });
+      this.notificationGateway.sendNotificationToUser(
+        userId,
+        notification as unknown as NotificationInterface,
+        NOTIFICATION_EVENTS.CREATED,
+      );
+    } catch (error) {
+      this.logger.warn(`Failed to create notification for userId=${userId}: ${error.message}`);
+    }
+  }
 
   private async checkIsAdmin(userId: string): Promise<boolean> {
     try {

--- a/apps/api/src/app/notification/notification.controller.ts
+++ b/apps/api/src/app/notification/notification.controller.ts
@@ -45,6 +45,18 @@ export class NotificationController {
   }
 
   // ====================================================
+  // GET - Get Notifications for Authenticated User (from JWT)
+  // NOTE: declared before :id to prevent route conflict
+  // ====================================================
+
+  @Get('me')
+  @ApiOperation({ summary: 'Get all notifications for the authenticated user' })
+  @ApiResponse({ status: 200, description: 'Notifications retrieved successfully', type: ResponseDto })
+  async findMyNotifications(@Req() req: Request & { user: { id: string } }) {
+    return this.notificationService.findMyNotifications(req.user.id);
+  }
+
+  // ====================================================
   // GET - Get All Notifications (admin / internal)
   // ====================================================
 
@@ -87,6 +99,24 @@ export class NotificationController {
     @Req() req: Request & { user: { id: string } },
   ) {
     return this.notificationService.findById(id, req.user.id);
+  }
+
+  // ====================================================
+  // PATCH - Mark Notification as Read
+  // NOTE: declared before :id to prevent route conflict
+  // ====================================================
+
+  @Patch(':id/read')
+  @ApiOperation({ summary: 'Mark a notification as read' })
+  @ApiParam({ name: 'id', type: String, description: 'UUID of the notification', example: 'uuid-notification-id' })
+  @ApiResponse({ status: 200, description: 'Notification marked as read', type: ResponseDto })
+  @ApiResponse({ status: 403, description: 'Access denied' })
+  @ApiResponse({ status: 404, description: 'Notification not found' })
+  async markAsRead(
+    @Param('id') id: string,
+    @Req() req: Request & { user: { id: string } },
+  ) {
+    return this.notificationService.markAsRead(id, req.user.id);
   }
 
   // ====================================================

--- a/apps/api/src/app/notification/notification.service.ts
+++ b/apps/api/src/app/notification/notification.service.ts
@@ -267,6 +267,96 @@ export class NotificationService {
   }
 
   // ====================================================
+  // GET MY NOTIFICATIONS (from JWT)
+  // ====================================================
+
+  async findMyNotifications(
+    authenticatedUserId: string,
+  ): Promise<ResponseDto<NotificationInterface[]>> {
+    try {
+      const notifications = await this.prisma.db.notification.findMany({
+        where: {
+          userId: authenticatedUserId,
+          status: { not: NotificationStatus.DELETED },
+        },
+        orderBy: { createdAt: 'desc' },
+      });
+
+      return {
+        status: ResponseStatus.Success,
+        statusCode: API_RESPONSE.SUCCESS.GET_NOTIFICATIONS.code,
+        message: API_RESPONSE.SUCCESS.GET_NOTIFICATIONS.message,
+        data: notifications as unknown as NotificationInterface[],
+      };
+    } catch (error) {
+      this.logger.error(error.message, error.stack);
+      return {
+        status: ResponseStatus.Error,
+        statusCode: API_RESPONSE.ERROR.GET_NOTIFICATIONS.code,
+        message: API_RESPONSE.ERROR.GET_NOTIFICATIONS.message,
+        data: null,
+      };
+    }
+  }
+
+  // ====================================================
+  // MARK AS READ
+  // ====================================================
+
+  async markAsRead(
+    id: string,
+    authenticatedUserId: string,
+  ): Promise<ResponseDto<NotificationInterface>> {
+    try {
+      const existing = await this.prisma.db.notification.findUnique({ where: { id } });
+
+      if (!existing || existing.status === NotificationStatus.DELETED) {
+        return {
+          status: ResponseStatus.Error,
+          statusCode: API_RESPONSE.ERROR.NOTIFICATION_NOT_FOUND.code,
+          message: API_RESPONSE.ERROR.NOTIFICATION_NOT_FOUND.message,
+          data: null,
+        };
+      }
+
+      if (existing.userId !== authenticatedUserId) {
+        return {
+          status: ResponseStatus.Error,
+          statusCode: API_RESPONSE.ERROR.NOTIFICATION_ACCESS_DENIED.code,
+          message: API_RESPONSE.ERROR.NOTIFICATION_ACCESS_DENIED.message,
+          data: null,
+        };
+      }
+
+      const updated = await this.prisma.db.notification.update({
+        where: { id },
+        data: { status: NotificationStatus.READ, readAt: new Date() },
+      });
+
+      this.notificationGateway.sendNotificationToUser(
+        updated.userId,
+        updated as unknown as NotificationInterface,
+        NOTIFICATION_EVENTS.UPDATED,
+      );
+
+      return {
+        status: ResponseStatus.Success,
+        statusCode: API_RESPONSE.SUCCESS.UPDATE_NOTIFICATION.code,
+        message: API_RESPONSE.SUCCESS.UPDATE_NOTIFICATION.message,
+        data: updated as unknown as NotificationInterface,
+      };
+    } catch (error) {
+      this.logger.error(error.message, error.stack);
+      return {
+        status: ResponseStatus.Error,
+        statusCode: API_RESPONSE.ERROR.UPDATE_NOTIFICATION.code,
+        message: API_RESPONSE.ERROR.UPDATE_NOTIFICATION.message,
+        data: null,
+      };
+    }
+  }
+
+  // ====================================================
   // SOFT DELETE
   // ====================================================
 

--- a/apps/api/src/app/search/search.controller.ts
+++ b/apps/api/src/app/search/search.controller.ts
@@ -2,6 +2,7 @@ import {
   Controller,
   ForbiddenException,
   Get,
+  Param,
   Query,
   Req,
   UseGuards,
@@ -9,6 +10,7 @@ import {
 import {
   ApiBearerAuth,
   ApiOperation,
+  ApiParam,
   ApiQuery,
   ApiResponse,
   ApiTags,
@@ -17,6 +19,7 @@ import { Request } from 'express';
 import { JwtGuardGuard } from '../jwt-guard/jwt-guard.guard';
 import { SearchService } from './search.service';
 import {
+  DaysInWeek,
   ResponseDto,
   SearchMentorDto,
   SearchSortBy,
@@ -29,6 +32,23 @@ import {
 @Controller('search')
 export class SearchController {
   constructor(private readonly searchService: SearchService) {}
+
+  // ====================================================
+  // GET /api/search – Mentor Search
+  // ====================================================
+
+  // ====================================================
+  // GET /api/search/mentor/:mentorId – Mentor Profile Detail
+  // ====================================================
+
+  @Get('mentor/:mentorId')
+  @ApiOperation({ summary: 'Get full mentor profile by mentor user ID' })
+  @ApiParam({ name: 'mentorId', type: String })
+  @ApiResponse({ status: 200, description: 'Mentor profile retrieved successfully', type: ResponseDto })
+  @ApiResponse({ status: 404, description: 'Mentor not found or not available' })
+  async getMentorProfile(@Param('mentorId') mentorId: string) {
+    return this.searchService.getMentorProfileById(mentorId);
+  }
 
   // ====================================================
   // GET /api/search – Mentor Search
@@ -49,7 +69,9 @@ Returns a paginated list of approved, active mentors.
 - \`skills\` — comma-separated skills (e.g. \`TypeScript,Node.js\`)
 - \`expertise\` — comma-separated expertise areas
 - \`minSessionRate\` / \`maxSessionRate\` — session rate range
-- \`minYearsExperience\` — minimum years of experience
+- \`minYearsExperience\` / \`maxYearsExperience\` — years of experience range
+- \`language\` — case-insensitive language filter
+- \`availabilityDay\` — filter by day of availability
 - \`sortBy\` — newest | sessionRate | yearsExperience | name
 - \`sortOrder\` — asc | desc
 - \`page\` / \`limit\` — pagination (limit max 50)
@@ -61,6 +83,9 @@ Returns a paginated list of approved, active mentors.
   @ApiQuery({ name: 'minSessionRate', required: false, type: Number })
   @ApiQuery({ name: 'maxSessionRate', required: false, type: Number })
   @ApiQuery({ name: 'minYearsExperience', required: false, type: Number })
+  @ApiQuery({ name: 'maxYearsExperience', required: false, type: Number })
+  @ApiQuery({ name: 'language', required: false, type: String })
+  @ApiQuery({ name: 'availabilityDay', required: false, enum: DaysInWeek })
   @ApiQuery({ name: 'sortBy', required: false, enum: SearchSortBy })
   @ApiQuery({ name: 'sortOrder', required: false, enum: SearchSortOrder })
   @ApiQuery({ name: 'page', required: false, type: Number })

--- a/apps/api/src/app/search/search.service.ts
+++ b/apps/api/src/app/search/search.service.ts
@@ -2,6 +2,8 @@ import { Injectable, Logger } from '@nestjs/common';
 import { PrismaService } from '../prisma/prisma.service';
 import {
   API_RESPONSE,
+  DaysInWeek,
+  MentorProfileDetailInterface,
   MentorSearchItemInterface,
   MentorSearchResultInterface,
   ResponseDto,
@@ -60,8 +62,9 @@ export class SearchService {
         });
 
         const sorted = this.sortInMemory(all as unknown as MentorSearchItemInterface[], sortBy, sortOrder);
-        total = sorted.length;
-        results = sorted.slice((page - 1) * limit, page * limit);
+        const filtered = this.filterByAvailabilityDay(sorted, dto.availabilityDay);
+        total = filtered.length;
+        results = filtered.slice((page - 1) * limit, page * limit);
       } else {
         const orderBy = this.buildOrderBy(sortBy, sortOrder);
         [total, results] = await Promise.all([
@@ -74,6 +77,8 @@ export class SearchService {
             take: limit,
           }) as unknown as Promise<MentorSearchItemInterface[]>,
         ]);
+        results = this.filterByAvailabilityDay(results, dto.availabilityDay);
+        total = results.length;
       }
 
       return {
@@ -126,6 +131,11 @@ export class SearchService {
       { isMentorApproved: true },
       { isMentorProfileComplete: true },
     ];
+
+    // Language filter (case-insensitive)
+    if (dto.language) {
+      topLevelAnd.push({ language: { equals: dto.language, mode: 'insensitive' } });
+    }
 
     // Name filter (partial, case-insensitive)
     if (dto.name?.trim()) {
@@ -183,9 +193,14 @@ export class SearchService {
       });
     }
 
-    // Minimum years of experience 
-    if (dto.minYearsExperience !== undefined) {
-      profileConditions.push({ yearsOfExperience: { gte: dto.minYearsExperience } });
+    // Years of experience range
+    if (dto.minYearsExperience !== undefined || dto.maxYearsExperience !== undefined) {
+      profileConditions.push({
+        yearsOfExperience: {
+          ...(dto.minYearsExperience !== undefined ? { gte: dto.minYearsExperience } : {}),
+          ...(dto.maxYearsExperience !== undefined ? { lte: dto.maxYearsExperience } : {}),
+        },
+      });
     }
 
     // Attach profile conditions. Always require at least one mentorProfile record.
@@ -248,5 +263,122 @@ export class SearchService {
 
       return 0;
     });
+  }
+
+  // ====================================================
+  // PRIVATE – AVAILABILITY DAY POST-FILTER
+  // ====================================================
+
+  private filterByAvailabilityDay(
+    mentors: MentorSearchItemInterface[],
+    day: DaysInWeek | undefined,
+  ): MentorSearchItemInterface[] {
+    if (!day) return mentors;
+
+    return mentors.filter((mentor) => {
+      const availability = mentor.mentorProfiles[0]?.availability;
+      if (!availability || !Array.isArray(availability)) return false;
+      return (availability as { day: string }[]).some(
+        (slot) => slot.day?.toLowerCase() === day.toLowerCase(),
+      );
+    });
+  }
+
+  // ====================================================
+  // GET MENTOR PROFILE BY ID
+  // ====================================================
+
+  async getMentorProfileById(
+    mentorId: string,
+  ): Promise<ResponseDto<MentorProfileDetailInterface | null>> {
+    try {
+      const profile = await this.prisma.db.mentorProfile.findUnique({
+        where: { userId: mentorId },
+        select: {
+          id: true,
+          title: true,
+          bio: true,
+          areasOfExpertise: true,
+          yearsOfExperience: true,
+          skills: true,
+          sessionRate: true,
+          availability: true,
+          linkedInUrl: true,
+          updatedAt: true,
+          user: {
+            select: {
+              id: true,
+              firstName: true,
+              middleName: true,
+              lastName: true,
+              suffix: true,
+              language: true,
+              country: true,
+              timezone: true,
+              status: true,
+              isMentorApproved: true,
+              isMentorProfileComplete: true,
+              avatarAttachments: {
+                select: { publicUrl: true, fileName: true },
+              },
+            },
+          },
+        },
+      });
+
+      if (
+        !profile ||
+        profile.user.status !== 'active' ||
+        !profile.user.isMentorApproved ||
+        !profile.user.isMentorProfileComplete
+      ) {
+        return {
+          status: ResponseStatus.Error,
+          statusCode: API_RESPONSE.ERROR.USER_NOT_FOUND.code,
+          message: 'Mentor not found or not available',
+          data: null,
+        };
+      }
+
+      const { user } = profile;
+      const result: MentorProfileDetailInterface = {
+        id: profile.id,
+        title: profile.title,
+        bio: profile.bio,
+        areasOfExpertise: profile.areasOfExpertise,
+        yearsOfExperience: profile.yearsOfExperience,
+        skills: profile.skills,
+        sessionRate: profile.sessionRate,
+        availability: profile.availability,
+        linkedInUrl: profile.linkedInUrl,
+        updatedAt: profile.updatedAt,
+        user: {
+          id: user.id,
+          firstName: user.firstName,
+          middleName: user.middleName,
+          lastName: user.lastName,
+          suffix: user.suffix,
+          language: user.language,
+          country: user.country,
+          timezone: user.timezone,
+          avatarAttachments: user.avatarAttachments,
+        },
+      };
+
+      return {
+        status: ResponseStatus.Success,
+        statusCode: API_RESPONSE.SUCCESS.GET_BOOKINGS.code,
+        message: 'Mentor profile retrieved successfully',
+        data: result,
+      };
+    } catch (error) {
+      this.logger.error(error.message, error.stack);
+      return {
+        status: ResponseStatus.Error,
+        statusCode: API_RESPONSE.ERROR.INTERNAL_SERVER_ERROR.code,
+        message: API_RESPONSE.ERROR.INTERNAL_SERVER_ERROR.message,
+        data: null,
+      };
+    }
   }
 }

--- a/lib/models/src/lib/dto/booking/booking.dto.ts
+++ b/lib/models/src/lib/dto/booking/booking.dto.ts
@@ -3,6 +3,27 @@ import { Type } from 'class-transformer';
 import { IsDate, IsEnum, IsNotEmpty, IsOptional, IsString, IsUrl, IsUUID } from 'class-validator';
 import { BookingInterface, BookingStatus } from '../../interfaces/booking/booking.model';
 
+export class MentorBookingsQueryDto {
+  @ApiPropertyOptional({
+    enum: BookingStatus,
+    description: 'Filter bookings by status',
+    example: BookingStatus.PENDING,
+  })
+  @IsOptional()
+  @IsEnum(BookingStatus)
+  status?: BookingStatus;
+}
+
+export class ApproveBookingDto {
+  @ApiProperty({
+    description: 'Video call or meeting link for the confirmed session',
+    example: 'https://meet.google.com/abc-defg-hij',
+  })
+  @IsUrl()
+  @IsNotEmpty()
+  sessionLink!: string;
+}
+
 export class CreateBookingDto implements Partial<BookingInterface> {
   @ApiProperty({
     description: 'UUID of the mentor to book a session with',

--- a/lib/models/src/lib/dto/constants/select-fields.const.ts
+++ b/lib/models/src/lib/dto/constants/select-fields.const.ts
@@ -27,6 +27,7 @@ export class SelectFields {
   static getMentorProfileSelect() {
     return {
       id: true,
+      title: true,
       areasOfExpertise: true,
       yearsOfExperience: true,
       linkedInUrl: true,
@@ -100,6 +101,7 @@ export class SelectFields {
       mentorProfiles: {
         select: {
           id: true,
+          title: true,
           areasOfExpertise: true,
           yearsOfExperience: true,
           bio: true,

--- a/lib/models/src/lib/dto/search/search-mentor.dto.ts
+++ b/lib/models/src/lib/dto/search/search-mentor.dto.ts
@@ -9,6 +9,7 @@ import {
   Max,
   Min,
 } from 'class-validator';
+import { DaysInWeek } from '../../interfaces/user/user.model';
 
 export enum SearchSortBy {
   NEWEST = 'newest',
@@ -76,6 +77,33 @@ export class SearchMentorDto {
   @IsInt()
   @Min(0)
   minYearsExperience?: number;
+
+  @ApiPropertyOptional({
+    description: 'Maximum years of experience',
+    example: 10,
+  })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(0)
+  maxYearsExperience?: number;
+
+  @ApiPropertyOptional({
+    description: 'Filter by mentor language (case-insensitive)',
+    example: 'English',
+  })
+  @IsOptional()
+  @IsString()
+  language?: string;
+
+  @ApiPropertyOptional({
+    enum: DaysInWeek,
+    description: 'Filter by availability day',
+    example: DaysInWeek.Monday,
+  })
+  @IsOptional()
+  @IsEnum(DaysInWeek)
+  availabilityDay?: DaysInWeek;
 
   @ApiPropertyOptional({
     description: 'Page number (1-based)',

--- a/lib/models/src/lib/interfaces/contants/contants.const.ts
+++ b/lib/models/src/lib/interfaces/contants/contants.const.ts
@@ -137,6 +137,22 @@ export const API_RESPONSE = {
       code: 200,
       message: 'Booking deleted successfully',
     },
+    GET_MENTOR_BOOKINGS: {
+      code: 200,
+      message: 'Mentor bookings retrieved successfully',
+    },
+    APPROVE_BOOKING: {
+      code: 200,
+      message: 'Booking approved successfully',
+    },
+    REJECT_BOOKING: {
+      code: 200,
+      message: 'Booking rejected successfully',
+    },
+    COMPLETE_BOOKING: {
+      code: 200,
+      message: 'Session marked as completed',
+    },
   },
   ERROR: {
     /**
@@ -371,6 +387,26 @@ export const API_RESPONSE = {
     BOOKING_ACCESS_DENIED: {
       code: 403,
       message: 'Access denied: booking does not belong to the authenticated user',
+    },
+    GET_MENTOR_BOOKINGS: {
+      code: 500,
+      message: 'Failed to get mentor bookings',
+    },
+    APPROVE_BOOKING: {
+      code: 500,
+      message: 'Failed to approve booking',
+    },
+    REJECT_BOOKING: {
+      code: 500,
+      message: 'Failed to reject booking',
+    },
+    COMPLETE_BOOKING: {
+      code: 500,
+      message: 'Failed to complete booking',
+    },
+    BOOKING_INVALID_TRANSITION: {
+      code: 400,
+      message: 'Invalid booking status transition',
     },
   }
 }

--- a/lib/models/src/lib/interfaces/search/search.model.ts
+++ b/lib/models/src/lib/interfaces/search/search.model.ts
@@ -15,8 +15,9 @@ export interface MentorSearchItemInterface {
   mentorProfiles: MentorProfileSearch[];
 }
 
-export interface MentorProfileSearch { 
+export interface MentorProfileSearch {
   id: string;
+  title: string | null;
   areasOfExpertise: string[];
   yearsOfExperience: number | null;
   bio: string | null;
@@ -25,6 +26,30 @@ export interface MentorProfileSearch {
   availability: unknown;
   linkedInUrl: string | null;
   updatedAt: Date;
+}
+
+export interface MentorProfileDetailInterface {
+  id: string;
+  title: string | null;
+  bio: string | null;
+  areasOfExpertise: string[];
+  yearsOfExperience: number | null;
+  skills: string[];
+  sessionRate: number | null;
+  availability: unknown;
+  linkedInUrl: string | null;
+  updatedAt: Date;
+  user: {
+    id: string;
+    firstName: string;
+    middleName: string | null;
+    lastName: string;
+    suffix: string | null;
+    language: string | null;
+    country: string | null;
+    timezone: string | null;
+    avatarAttachments: { publicUrl: string; fileName: string }[];
+  };
 }
 
 export interface MenttorAttachmentSearch {


### PR DESCRIPTION
# Ticket: #112 and #114 

## Changes

  New mentor-specific endpoints:
  - GET /booking/mentor — returns the authenticated mentor's bookings; supports ?status= filter for tab-based views (Pending /
  Confirmed / Completed / Cancelled)
  - PATCH /booking/:id/approve — PENDING → APPROVED; requires sessionLink in body
  - PATCH /booking/:id/reject — PENDING → REJECTED
  - PATCH /booking/:id/complete — APPROVED → COMPLETED; guards that sessionDateTime is in the past

  State machine: all transitions validated; invalid attempts return 400 BOOKING_INVALID_TRANSITION. Mentor ownership enforced on all
  mutating actions.

  Side effect: booking creation now triggers a BOOKING notification to the mentor via DB + WebSocket.
  Status changes (approve/reject/complete) trigger a BOOKING or SESSION notification to the mentee.

  Notification (/notification)

  - GET /notification/me — retrieves non-deleted notifications for the JWT user (no userId path param needed)
  - PATCH /notification/:id/read — dedicated mark-as-read; no body, sets status=READ and readAt=now

  Models (@gurokonekt/models)

  - MentorBookingsQueryDto — optional status query param
  - ApproveBookingDto — required sessionLink URL
  - New API_RESPONSE constants: APPROVE_BOOKING, REJECT_BOOKING, COMPLETE_BOOKING, GET_MENTOR_BOOKINGS, BOOKING_INVALID_TRANSITION