### PR TITLE
fix(sidebar): restore profile settings navigation item

### DIFF
--- a/apps/web/src/app/components/shared/navbar/mentee-navbar/mentee-navbar.html
+++ b/apps/web/src/app/components/shared/navbar/mentee-navbar/mentee-navbar.html
@@ -106,20 +106,12 @@
             <ul class="p-2 text-sm font-medium text-body" role="none">
 
               <li>
-                <a [routerLink]="'/mentee/profile-settings'" class="inline-flex w-full items-center rounded p-2 hover:bg-neutral-tertiary-medium hover:text-heading"
-                  role="menuitem">
-                  Profile Settings
-                </a>
-              </li>
-
-              <li>
                 <button (click)="logout()" type="button"
                   class="inline-flex w-full items-center rounded p-2 hover:bg-neutral-tertiary-medium hover:text-heading"
                   role="menuitem">
                   Sign out
                 </button>
               </li>
-
 
             </ul>
           </div>

--- a/apps/web/src/app/components/shared/sidebars/mentee-sidebar/mentee-sidebar.html
+++ b/apps/web/src/app/components/shared/sidebars/mentee-sidebar/mentee-sidebar.html
@@ -1,6 +1,6 @@
 <aside id="top-bar-sidebar"
   class="fixed top-0 left-0 z-50 w-64 h-full transition-transform -translate-x-full sm:translate-x-0"
-  aria-label="Sidebar" >
+  aria-label="Sidebar">
   <div class="flex h-full flex-col overflow-y-auto border-e border-default bg-neutral-primary-soft px-3 py-4">
     <a [routerLink]="'mentee-dashboard'" class="flex items-center ps-2.5 mb-5  justify-start">
       <img src="assets/logos/logo-light.svg" class="h-12 me-1" alt="Flowbite Logo" />
@@ -9,47 +9,65 @@
         <span class="text-xl font-bold text-orange-500">Konekt</span>
       </div>
     </a>
+    <nav class="space-y-1 flex flex-col justify-between align-middle h-full py-3">
 
 
-    <ul class="space-y-2 px-4 font-medium">
+      <ul class="space-y-2  font-medium">
 
 
-      <!-- <h4 class="text-gray-500 py-3">Main Menu</h4> -->
+        <!-- <h4 class="text-gray-500 py-3">Main Menu</h4> -->
 
-      <li>
+        <li>
 
-        <a [routerLink]="['/mentee/dashboard']"
-          routerLinkActive="bg-orange-50 text-orange-600 border-l-4 border-orange-500"
-          [routerLinkActiveOptions]="{exact: false}"
-          class="flex items-center gap-3 px-4 py-3 text-gray-600  font-medium rounded-lg hover:bg-gray-50 hover:text-gray-900 transition-all group relative">
-          <app-icon [name]="'chart-bar'" class="h-5 w-5 transition-transform group-hover:scale-110"></app-icon>
-          <span class="truncate">Dashboard</span>
-        </a>
-      </li>
+          <a [routerLink]="['/mentee/dashboard']"
+            routerLinkActive="bg-orange-50 text-orange-600 border-l-4 border-orange-500"
+            [routerLinkActiveOptions]="{exact: false}"
+            class="flex items-center gap-3 px-4 py-3 text-gray-600  font-medium rounded-lg hover:bg-gray-50 hover:text-gray-900 transition-all group relative">
+            <app-icon [name]="'chart-bar'" class="h-5 w-5 transition-transform group-hover:scale-110"></app-icon>
+            <span class="truncate">Dashboard</span>
+          </a>
+        </li>
 
-      <li>
+        <li>
 
-        <a [routerLink]="['/mentee/find-mentors']" routerLinkActive="bg-orange-50 text-orange-600 border-l-4 border-orange-500"
-          [routerLinkActiveOptions]="{exact: false}"
-          class="flex items-center gap-3 px-4 py-3 text-gray-600  font-medium rounded-lg hover:bg-gray-50 hover:text-gray-900 transition-all group relative">
-          <app-icon [name]="'users'" class="h-5 w-5 transition-transform group-hover:scale-110"></app-icon>
-          <span class="truncate">Find Mentors</span>
-        </a>
-      </li>
+          <a [routerLink]="['/mentee/find-mentors']"
+            routerLinkActive="bg-orange-50 text-orange-600 border-l-4 border-orange-500"
+            [routerLinkActiveOptions]="{exact: false}"
+            class="flex items-center gap-3 px-4 py-3 text-gray-600  font-medium rounded-lg hover:bg-gray-50 hover:text-gray-900 transition-all group relative">
+            <app-icon [name]="'users'" class="h-5 w-5 transition-transform group-hover:scale-110"></app-icon>
+            <span class="truncate">Find Mentors</span>
+          </a>
+        </li>
 
 
-      <li>
+        <li>
 
-        <a [routerLink]="'booking-overview'"
-          routerLinkActive="bg-orange-50 text-orange-600 border-l-4 border-orange-500"
-          [routerLinkActiveOptions]="{exact: false}"
-          class="flex items-center gap-3 px-4 py-3 text-gray-600  font-medium rounded-lg hover:bg-gray-50 hover:text-gray-900 transition-all group relative">
-          <app-icon [name]="'book-open'" class="h-5 w-5 transition-transform group-hover:scale-110"></app-icon>
-          <span class="truncate">Booking</span>
-        </a>
-      </li>
+          <a [routerLink]="'booking-overview'"
+            routerLinkActive="bg-orange-50 text-orange-600 border-l-4 border-orange-500"
+            [routerLinkActiveOptions]="{exact: false}"
+            class="flex items-center gap-3 px-4 py-3 text-gray-600  font-medium rounded-lg hover:bg-gray-50 hover:text-gray-900 transition-all group relative">
+            <app-icon [name]="'book-open'" class="h-5 w-5 transition-transform group-hover:scale-110"></app-icon>
+            <span class="truncate">Booking</span>
+          </a>
+        </li>
 
-    </ul>
+      </ul>
+
+      <!-- Bottom Navigation -->
+      <ul class="space-y-2 font-medium">
+      <div class="my-4 border-t border-gray-200"></div>
+
+        <li>
+          <a [routerLink]="'profile-settings'"
+            routerLinkActive="bg-orange-50 text-orange-600 border-l-4 border-orange-500"
+            [routerLinkActiveOptions]="{exact: false}"
+            class="flex items-center gap-3 px-4 py-3 text-gray-600  font-medium rounded-lg hover:bg-gray-50 hover:text-gray-900 transition-all group relative">
+            <app-icon [name]="'cog-6-tooth'" class="h-5 w-5 transition-transform group-hover:scale-110"></app-icon>
+            <span class="truncate">Profile Settings</span>
+          </a>
+        </li>
+      </ul>
+    </nav>
 
 
   </div>


### PR DESCRIPTION




## Summary

This PR fixes the missing **Profile Settings** option in the sidebar after the recent dashboard-related PR merge.

Restored the missing **Profile Settings** option in the sidebar after it was removed during the dashboard PR merge.

## Changes Made


- [fix(sidebar): restore profile settings navigation item](https://github.com/Angular-PH-X-GuroKonekt-PH/gurokonekt-monorepo/commit/840d18ea54c894bc24bd8f5b8af8d5fbc13299ee)

- Restored the **Profile Settings** navigation item in the sidebar
- Reconnected the sidebar item to the existing Profile Settings route/page
- Verified that the sidebar option is visible and accessible again

## Related Issue

Closes #183