### PR TITLE
feat(auth): add emailRedirectTo parameter for email verification link…

### DIFF
--- a/apps/api/src/app/auth/auth.controller.ts
+++ b/apps/api/src/app/auth/auth.controller.ts
@@ -74,9 +74,10 @@ export class AuthController {
   async registerMentee(
     @Body() input: RegisterMenteeDto,
     @Ip() ipAddress: string,
-    @Headers('user-agent') userAgent: string
+    @Headers('user-agent') userAgent: string,
+    @Headers('origin') origin: string,
   ) {
-    const response = await this.authService.registerMentee(input, ipAddress, userAgent);
+    const response = await this.authService.registerMentee(input, ipAddress, userAgent, origin);
     
     // If service returns an error status, throw the appropriate HTTP exception
     if (response.status === ResponseStatus.Error) {
@@ -130,8 +131,9 @@ export class AuthController {
     @UploadedFiles() files: Express.Multer.File[],
     @Ip() ipAddress: string,
     @Headers('user-agent') userAgent: string,
+    @Headers('origin') origin: string,
   ) {
-    const response = await this.authService.registerMentor(input, files, ipAddress, userAgent);
+    const response = await this.authService.registerMentor(input, files, ipAddress, userAgent, origin);
     
     // If service returns an error status, throw the appropriate HTTP exception
     if (response.status === ResponseStatus.Error) {
@@ -288,9 +290,10 @@ export class AuthController {
   async resendSignUp(
     @Body() input: ResendConfirmationEmailDto,
     @Ip() ipAddress: string,
-    @Headers('user-agent') userAgent: string
+    @Headers('user-agent') userAgent: string,
+    @Headers('origin') origin: string,
   ) {
-    const response = await this.authService.resendEmailSignUpConfirmation(input, ipAddress, userAgent);
+    const response = await this.authService.resendEmailSignUpConfirmation(input, ipAddress, userAgent, origin);
     
     if (response.status === ResponseStatus.Error) {
       throw new HttpException(

--- a/apps/api/src/app/auth/auth.service.ts
+++ b/apps/api/src/app/auth/auth.service.ts
@@ -31,7 +31,7 @@ export class AuthService {
    * 8. confirmation email will be sent automatically after signup as per the 
    *    configuration in the supabase authentication
    * */ 
-  async registerMentee(dto: RegisterMenteeDto, ipAddress: string, userAgent: string): Promise<ResponseDto> {
+  async registerMentee(dto: RegisterMenteeDto, ipAddress: string, userAgent: string, origin?: string): Promise<ResponseDto> {
     // Normalize email to lowercase and trim whitespace
     const normalizedEmail = dto.email.toLowerCase().trim();
 
@@ -52,10 +52,12 @@ export class AuthService {
       }
 
       // Create user in Supabase Auth
+      const emailRedirectTo = dto.emailRedirectTo ?? `${origin ?? ''}${REDIRECT_LINKS.VERIFY_EMAIL}`;
       const { data, error } = await this.supabase.client.auth.signUp({
         email: normalizedEmail,
-        password: dto.password
-      });   
+        password: dto.password,
+        options: { emailRedirectTo },
+      });
 
       if (error) {
         this.logger.error(error.message, error.stack);
@@ -179,7 +181,7 @@ export class AuthService {
    * 9. save the data to the DocumentAttachment table 
    * 10. if error occured, return error else return success with status 200
    * */ 
-  async registerMentor(dto: RegisterMentorDto, files: Express.Multer.File[], ipAddress: string, userAgent: string): Promise<ResponseDto> {
+  async registerMentor(dto: RegisterMentorDto, files: Express.Multer.File[], ipAddress: string, userAgent: string, origin?: string): Promise<ResponseDto> {
     // Normalize email to lowercase and trim whitespace
     const normalizedEmail = dto.email.toLowerCase().trim();
 
@@ -198,10 +200,12 @@ export class AuthService {
         };
       }
 
+      const emailRedirectTo = dto.emailRedirectTo ?? `${origin ?? ''}${REDIRECT_LINKS.VERIFY_EMAIL}`;
       const { data, error } = await this.supabase.client.auth.signUp({
         email: normalizedEmail,
-        password: dto.password
-      });   
+        password: dto.password,
+        options: { emailRedirectTo },
+      });
 
       if (error) {
         this.logger.error(error.message, error.stack);
@@ -235,7 +239,7 @@ export class AuthService {
 
       const authId = data.user.id;
       const hashPassword = await bcrypt.hash(dto.password, 10);
-      const transaction = await this.prisma.db.$transaction(async (tx) => { 
+      const transaction = await this.prisma.db.$transaction(async (tx) => {
         const mentor = await tx.user.create({
           data: {
             id: authId,
@@ -340,7 +344,7 @@ export class AuthService {
    * 8. if confirmed return error else send confirmation email
    * 9. save the activity to logs
    * */ 
-  async resendEmailSignUpConfirmation(input: ResendConfirmationEmailDto, ipAddress: string, userAgent: string): Promise<ResponseDto> {
+  async resendEmailSignUpConfirmation(input: ResendConfirmationEmailDto, ipAddress: string, userAgent: string, origin?: string): Promise<ResponseDto> {
     try {
       if (process.env.NODE_ENV !== 'test') {
         const todayStart = new Date();
@@ -445,9 +449,11 @@ export class AuthService {
       }
 
       // Resend email via Supabase
+      const emailRedirectTo = input.emailRedirectTo ?? `${origin ?? ''}${REDIRECT_LINKS.VERIFY_EMAIL}`;
       const { data, error } = await this.supabase.client.auth.resend({
         type: ResendOTPTypes.SignUp,
-        email: input.email
+        email: input.email,
+        options: { emailRedirectTo },
       });
 
       // Log the attempt

--- a/firebase-debug.log
+++ b/firebase-debug.log
@@ -122,3 +122,67 @@
 [debug] [2026-05-02T09:43:26.191Z] <<< [apiv2][body] POST https://www.googleapis.com/oauth2/v3/token [omitted]
 [debug] [2026-05-02T09:43:26.206Z] >>> [apiv2][query] GET https://cloudbilling.googleapis.com/v1/projects/gurokonekt/billingInfo [none]
 [debug] [2026-05-02T09:43:27.682Z] <<< [apiv2][status] GET https://cloudbilling.googleapis.com/v1/projects/gurokonekt/billingInfo 403
+[debug] [2026-05-06T21:29:13.863Z] > command requires scopes: ["email","openid","https://www.googleapis.com/auth/cloudplatformprojects.readonly","https://www.googleapis.com/auth/firebase","https://www.googleapis.com/auth/cloud-platform"]
+[debug] [2026-05-06T21:29:13.877Z] > authorizing via signed-in user (arw.oloroso@gmail.com)
+[debug] [2026-05-06T21:29:13.878Z] > command requires scopes: ["email","openid","https://www.googleapis.com/auth/cloudplatformprojects.readonly","https://www.googleapis.com/auth/firebase","https://www.googleapis.com/auth/cloud-platform"]
+[debug] [2026-05-06T21:29:13.878Z] > authorizing via signed-in user (arw.oloroso@gmail.com)
+[debug] [2026-05-06T21:29:13.882Z] Checked if tokens are valid: false, expires at: 1778103418453
+[debug] [2026-05-06T21:29:13.883Z] Checked if tokens are valid: false, expires at: 1778103418453
+[debug] [2026-05-06T21:29:13.884Z] > refreshing access token with scopes: []
+[debug] [2026-05-06T21:29:13.891Z] >>> [apiv2][query] POST https://www.googleapis.com/oauth2/v3/token [none]
+[debug] [2026-05-06T21:29:13.892Z] >>> [apiv2][body] POST https://www.googleapis.com/oauth2/v3/token [omitted]
+[debug] [2026-05-06T21:29:13.902Z] Checked if tokens are valid: false, expires at: 1778103418453
+[debug] [2026-05-06T21:29:13.903Z] Checked if tokens are valid: false, expires at: 1778103418453
+[debug] [2026-05-06T21:29:13.903Z] > refreshing access token with scopes: []
+[debug] [2026-05-06T21:29:13.905Z] >>> [apiv2][query] POST https://www.googleapis.com/oauth2/v3/token [none]
+[debug] [2026-05-06T21:29:13.906Z] >>> [apiv2][body] POST https://www.googleapis.com/oauth2/v3/token [omitted]
+[debug] [2026-05-06T21:29:13.910Z] > command requires scopes: ["email","openid","https://www.googleapis.com/auth/cloudplatformprojects.readonly","https://www.googleapis.com/auth/firebase","https://www.googleapis.com/auth/cloud-platform"]
+[debug] [2026-05-06T21:29:13.910Z] > authorizing via signed-in user (arw.oloroso@gmail.com)
+[debug] [2026-05-06T21:29:13.911Z] Checked if tokens are valid: false, expires at: 1778103418453
+[debug] [2026-05-06T21:29:13.911Z] Checked if tokens are valid: false, expires at: 1778103418453
+[debug] [2026-05-06T21:29:13.912Z] > refreshing access token with scopes: []
+[debug] [2026-05-06T21:29:13.913Z] >>> [apiv2][query] POST https://www.googleapis.com/oauth2/v3/token [none]
+[debug] [2026-05-06T21:29:13.913Z] >>> [apiv2][body] POST https://www.googleapis.com/oauth2/v3/token [omitted]
+[debug] [2026-05-06T21:29:14.148Z] <<< [apiv2][status] POST https://www.googleapis.com/oauth2/v3/token 200
+[debug] [2026-05-06T21:29:14.148Z] <<< [apiv2][body] POST https://www.googleapis.com/oauth2/v3/token [omitted]
+[debug] [2026-05-06T21:29:14.183Z] >>> [apiv2][query] GET https://cloudbilling.googleapis.com/v1/projects/gurokonekt/billingInfo [none]
+[debug] [2026-05-06T21:29:14.194Z] <<< [apiv2][status] POST https://www.googleapis.com/oauth2/v3/token 200
+[debug] [2026-05-06T21:29:14.195Z] <<< [apiv2][body] POST https://www.googleapis.com/oauth2/v3/token [omitted]
+[debug] [2026-05-06T21:29:14.209Z] >>> [apiv2][query] GET https://cloudbilling.googleapis.com/v1/projects/gurokonekt/billingInfo [none]
+[debug] [2026-05-06T21:29:14.215Z] <<< [apiv2][status] POST https://www.googleapis.com/oauth2/v3/token 200
+[debug] [2026-05-06T21:29:14.215Z] <<< [apiv2][body] POST https://www.googleapis.com/oauth2/v3/token [omitted]
+[debug] [2026-05-06T21:29:14.229Z] >>> [apiv2][query] GET https://cloudbilling.googleapis.com/v1/projects/gurokonekt/billingInfo [none]
+[debug] [2026-05-06T21:29:15.747Z] <<< [apiv2][status] GET https://cloudbilling.googleapis.com/v1/projects/gurokonekt/billingInfo 403
+[debug] [2026-05-06T21:29:15.748Z] <<< [apiv2][body] GET https://cloudbilling.googleapis.com/v1/projects/gurokonekt/billingInfo {"error":{"code":403,"message":"The caller does not have permission","status":"PERMISSION_DENIED"}}
+[debug] [2026-05-06T21:29:15.895Z] <<< [apiv2][status] GET https://cloudbilling.googleapis.com/v1/projects/gurokonekt/billingInfo 403
+[debug] [2026-05-06T22:21:46.615Z] > command requires scopes: ["email","openid","https://www.googleapis.com/auth/cloudplatformprojects.readonly","https://www.googleapis.com/auth/firebase","https://www.googleapis.com/auth/cloud-platform"]
+[debug] [2026-05-06T22:21:46.636Z] > authorizing via signed-in user (arw.oloroso@gmail.com)
+[debug] [2026-05-06T22:21:46.643Z] Checked if tokens are valid: false, expires at: 1778106553216
+[debug] [2026-05-06T22:21:46.644Z] Checked if tokens are valid: false, expires at: 1778106553216
+[debug] [2026-05-06T22:21:46.647Z] > refreshing access token with scopes: []
+[debug] [2026-05-06T22:21:46.662Z] >>> [apiv2][query] POST https://www.googleapis.com/oauth2/v3/token [none]
+[debug] [2026-05-06T22:21:46.664Z] >>> [apiv2][body] POST https://www.googleapis.com/oauth2/v3/token [omitted]
+[debug] [2026-05-06T22:21:46.802Z] > command requires scopes: ["email","openid","https://www.googleapis.com/auth/cloudplatformprojects.readonly","https://www.googleapis.com/auth/firebase","https://www.googleapis.com/auth/cloud-platform"]
+[debug] [2026-05-06T22:21:46.803Z] > authorizing via signed-in user (arw.oloroso@gmail.com)
+[debug] [2026-05-06T22:21:46.804Z] > command requires scopes: ["email","openid","https://www.googleapis.com/auth/cloudplatformprojects.readonly","https://www.googleapis.com/auth/firebase","https://www.googleapis.com/auth/cloud-platform"]
+[debug] [2026-05-06T22:21:46.804Z] > authorizing via signed-in user (arw.oloroso@gmail.com)
+[debug] [2026-05-06T22:21:46.806Z] Checked if tokens are valid: false, expires at: 1778106553216
+[debug] [2026-05-06T22:21:46.807Z] Checked if tokens are valid: false, expires at: 1778106553216
+[debug] [2026-05-06T22:21:46.807Z] > refreshing access token with scopes: []
+[debug] [2026-05-06T22:21:46.809Z] >>> [apiv2][query] POST https://www.googleapis.com/oauth2/v3/token [none]
+[debug] [2026-05-06T22:21:46.809Z] >>> [apiv2][body] POST https://www.googleapis.com/oauth2/v3/token [omitted]
+[debug] [2026-05-06T22:21:46.816Z] Checked if tokens are valid: false, expires at: 1778106553216
+[debug] [2026-05-06T22:21:46.816Z] Checked if tokens are valid: false, expires at: 1778106553216
+[debug] [2026-05-06T22:21:46.817Z] > refreshing access token with scopes: []
+[debug] [2026-05-06T22:21:46.818Z] >>> [apiv2][query] POST https://www.googleapis.com/oauth2/v3/token [none]
+[debug] [2026-05-06T22:21:46.818Z] >>> [apiv2][body] POST https://www.googleapis.com/oauth2/v3/token [omitted]
+[debug] [2026-05-06T22:21:47.059Z] <<< [apiv2][status] POST https://www.googleapis.com/oauth2/v3/token 200
+[debug] [2026-05-06T22:21:47.060Z] <<< [apiv2][body] POST https://www.googleapis.com/oauth2/v3/token [omitted]
+[debug] [2026-05-06T22:21:47.630Z] >>> [apiv2][query] GET https://cloudbilling.googleapis.com/v1/projects/gurokonekt/billingInfo [none]
+[debug] [2026-05-06T22:21:47.646Z] <<< [apiv2][status] POST https://www.googleapis.com/oauth2/v3/token 200
+[debug] [2026-05-06T22:21:47.647Z] <<< [apiv2][body] POST https://www.googleapis.com/oauth2/v3/token [omitted]
+[debug] [2026-05-06T22:21:47.803Z] >>> [apiv2][query] GET https://cloudbilling.googleapis.com/v1/projects/gurokonekt/billingInfo [none]
+[debug] [2026-05-06T22:21:47.810Z] <<< [apiv2][status] POST https://www.googleapis.com/oauth2/v3/token 200
+[debug] [2026-05-06T22:21:47.810Z] <<< [apiv2][body] POST https://www.googleapis.com/oauth2/v3/token [omitted]
+[debug] [2026-05-06T22:21:47.826Z] >>> [apiv2][query] GET https://cloudbilling.googleapis.com/v1/projects/gurokonekt/billingInfo [none]
+[debug] [2026-05-06T22:21:49.459Z] <<< [apiv2][status] GET https://cloudbilling.googleapis.com/v1/projects/gurokonekt/billingInfo 403

--- a/lib/models/src/lib/dto/auth/signin.dto.ts
+++ b/lib/models/src/lib/dto/auth/signin.dto.ts
@@ -1,8 +1,10 @@
-import { 
-  IsEmail, 
-  IsEnum, 
-  IsNotEmpty, 
-  IsString 
+import {
+  IsEmail,
+  IsEnum,
+  IsNotEmpty,
+  IsOptional,
+  IsString,
+  IsUrl,
 } from 'class-validator';
 import { 
   ResendConfirmationEmailInterface, 
@@ -32,4 +34,8 @@ export class ResendConfirmationEmailDto implements ResendConfirmationEmailInterf
 
   @IsEmail({}, { message: 'Email must be a valid email address' })
   email!: string;
+
+  @IsOptional()
+  @IsUrl({}, { message: 'emailRedirectTo must be a valid URL' })
+  emailRedirectTo?: string;
 }

--- a/lib/models/src/lib/dto/auth/signup-mentee.dto.ts
+++ b/lib/models/src/lib/dto/auth/signup-mentee.dto.ts
@@ -1,6 +1,6 @@
 import { API_RESPONSE, REGEX, RegisterMenteeRequest } from '@gurokonekt/models';
 import { ApiProperty } from '@nestjs/swagger';
-import { IsEmail, IsOptional, IsString, Matches } from 'class-validator';
+import { IsEmail, IsOptional, IsString, IsUrl, Matches } from 'class-validator';
 import { CustomMatch } from '../decorators/custom-matches.decorator';
 
 export class RegisterMenteeDto implements RegisterMenteeRequest {
@@ -81,8 +81,17 @@ export class RegisterMenteeDto implements RegisterMenteeRequest {
   })
   @IsString()
   @Matches(
-    REGEX.PHONE, 
+    REGEX.PHONE,
     { message: API_RESPONSE.ERROR.INVALID_PHONE_FORMAT.message }
   )
   phoneNumber!: string;
-} 
+
+  @ApiProperty({
+    required: false,
+    example: 'https://app.gurokonekt.com/verify-email',
+    description: 'URL to redirect to after clicking the confirmation link. Defaults to the request origin + /verify-email.',
+  })
+  @IsOptional()
+  @IsUrl({}, { message: 'emailRedirectTo must be a valid URL' })
+  emailRedirectTo?: string;
+}

--- a/lib/models/src/lib/dto/auth/signup-mentor.dto.ts
+++ b/lib/models/src/lib/dto/auth/signup-mentor.dto.ts
@@ -135,4 +135,13 @@ export class RegisterMentorDto implements RegisterMentorRequest {
     description: 'Array of files uploaded by the mentor (e.g., resume, portfolio). Each file should include necessary metadata such as filename, file type, and file size.',
   })
     files!: any[];
+
+  @ApiProperty({
+    required: false,
+    example: 'https://app.gurokonekt.com/verify-email',
+    description: 'URL to redirect to after clicking the confirmation link. Defaults to the request origin + /verify-email.',
+  })
+  @IsOptional()
+  @IsUrl({}, { message: 'emailRedirectTo must be a valid URL' })
+  emailRedirectTo?: string;
 }

--- a/lib/models/src/lib/interfaces/auth/register-mentee-request.interface.ts
+++ b/lib/models/src/lib/interfaces/auth/register-mentee-request.interface.ts
@@ -10,4 +10,5 @@ export interface RegisterMenteeRequest {
   language: string;
   timezone: string;
   phoneNumber: string;
+  emailRedirectTo?: string;
 }

--- a/lib/models/src/lib/interfaces/auth/register-mentor-request.interface.ts
+++ b/lib/models/src/lib/interfaces/auth/register-mentor-request.interface.ts
@@ -14,4 +14,5 @@ export interface RegisterMentorRequest {
   linkedInUrl?: string;
   areasOfExpertise: string[];
   files: any[];
+  emailRedirectTo?: string;
 }

--- a/lib/models/src/lib/interfaces/auth/signin.model.ts
+++ b/lib/models/src/lib/interfaces/auth/signin.model.ts
@@ -22,4 +22,5 @@ export interface SignInWithOAthInterface {
 export interface ResendConfirmationEmailInterface {
   type: ResendOTPTypes.SignUp;
   email: string;
+  emailRedirectTo?: string;
 }

--- a/lib/models/src/lib/interfaces/contants/contants.const.ts
+++ b/lib/models/src/lib/interfaces/contants/contants.const.ts
@@ -1237,6 +1237,7 @@ export const REDIRECT_LINKS  = {
   RESET_PASSWORD: '/reset-password',
   DEACTIVATE_ACCOUNT: '/deactivate',
   PASSWORD_CHANGE_VERIFY: '/update-password/verify',
+  VERIFY_EMAIL: '/verify-email',
 }
 
 export const RESEND_EMAIL_CONFIRMATION = {


### PR DESCRIPTION
# Ticket: #179 

## Changes

  - Added optional emailRedirectTo field to RegisterMenteeDto, RegisterMentorDto, and ResendConfirmationEmailDto — validated as a URL when provided                                                                                 
  - Updated registerMentee, registerMentor, and resendEmailSignUpConfirmation service methods to pass emailRedirectTo to Supabase's signUp() and resend() calls
  - Resolution order: explicit emailRedirectTo from the request body → Origin header + /verify-email path (fallback)                                                                                                                
  - Added REDIRECT_LINKS.VERIFY_EMAIL = '/verify-email' to the shared constants
                                                                                                                                                                                                                              
  If the frontend sends emailRedirectTo: "https://test.domain.com/verify-email" in the body, Supabase uses that. If omitted, the API derives it from the Origin request header so the confirmation link always points back to       
  whichever domain triggered the registration.