### PR TITLE
fix(fe): Previous button hidden from the first page of registration

### DIFF
--- a/apps/web/src/app/core/auth/pages/registration-page/registration-mentee-page/registration-mentee.page.html
+++ b/apps/web/src/app/core/auth/pages/registration-page/registration-mentee-page/registration-mentee.page.html
@@ -561,17 +561,20 @@
           class="flex items-center justify-between mt-8 pt-6 border-t border-gray-200"
         >
           <!-- Previous Button -->
+          @if (currentStep() > 1) {
           <button
             type="button"
             (click)="previousStep()"
             (keyup.enter)="previousStep()"
             (keyup.space)="previousStep()"
-            [disabled]="currentStep() === 1"
             class="flex items-center gap-2 px-6 py-3 rounded-xl border-2 border-gray-300 text-gray-700 font-semibold hover:border-gray-400 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
           >
             <app-icon name="chevron-left" class="w-5 h-5"></app-icon>
             Previous
           </button>
+          } @else {
+          <div></div>
+          }
 
           <!-- Progress indicator -->
           <div class="text-sm text-gray-500">


### PR DESCRIPTION
- Previous button was already hidden on the first page of mentee registration form same as the first page of mentor registration form. This is the fix for ticket #177