### PR TITLE
fix: remove availability field from mentee profile and related services (#219)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,5 @@ apps/api/.env
 CLAUDE.md
 docs
 postman
+apps/api/.env.prod
+apps/api/.env.test

--- a/apps/api/prisma/migrations/20260517000000_remove_mentee_availability/migration.sql
+++ b/apps/api/prisma/migrations/20260517000000_remove_mentee_availability/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "mentee_profiles" DROP COLUMN "availability";

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -144,7 +144,6 @@ model MenteeProfile {
   learningGoals        String[]                   @map("learning_goals")
   areasOfInterest      String[]                   @map("areas_of_interest")
   preferredSessionType MenteePreferredSessionType @map("preferred_session_type")
-  availability         Json
   updatedById          String?                    @map("updated_by_id")
   updatedAt            DateTime                   @updatedAt @map("updated_at")
 

--- a/apps/api/src/app/user/user.service.ts
+++ b/apps/api/src/app/user/user.service.ts
@@ -568,24 +568,10 @@ export class UserService {
               if (typeof value === 'string' && value.trim().length > 0) return [value];
               return undefined;
             };
-            const normalizeAvailability = (value: unknown): UpdateMenteeProfileDto['availability'] => {
-              if (Array.isArray(value)) return value;
-              if (typeof value === 'string') {
-                try {
-                  const parsed = JSON.parse(value);
-                  return Array.isArray(parsed) ? parsed : undefined;
-                } catch {
-                  return undefined;
-                }
-              }
-              return undefined;
-            };
-
             return {
               ...currentDto,
               learningGoals: normalizeToArray(currentDto.learningGoals),
               areasOfInterest: normalizeToArray(currentDto.areasOfInterest),
-              availability: normalizeAvailability(currentDto.availability),
             };
           })()
         : (() => {
@@ -680,7 +666,6 @@ export class UserService {
           learningGoals: currentDto.learningGoals,
           areasOfInterest: currentDto.areasOfInterest,
           preferredSessionType: currentDto.preferredSessionType,
-          availability: instanceToPlain(currentDto.availability),
           updatedById: currentDto.updatedById,
         };
         await this.prisma.db.$transaction(async (tx) => {

--- a/firebase-debug.log
+++ b/firebase-debug.log
@@ -186,3 +186,5 @@
 [debug] [2026-05-06T22:21:47.810Z] <<< [apiv2][body] POST https://www.googleapis.com/oauth2/v3/token [omitted]
 [debug] [2026-05-06T22:21:47.826Z] >>> [apiv2][query] GET https://cloudbilling.googleapis.com/v1/projects/gurokonekt/billingInfo [none]
 [debug] [2026-05-06T22:21:49.459Z] <<< [apiv2][status] GET https://cloudbilling.googleapis.com/v1/projects/gurokonekt/billingInfo 403
+[debug] [2026-05-17T15:31:13.584Z] > command requires scopes: ["email","openid","https://www.googleapis.com/auth/cloudplatformprojects.readonly","https://www.googleapis.com/auth/firebase","https://www.googleapis.com/auth/cloud-platform"]
+[debug] [2026-05-17T15:31:13.595Z] > authorizing via signed-in user (arw.oloroso@gmail.com)

--- a/lib/models/src/lib/dto/constants/select-fields.const.ts
+++ b/lib/models/src/lib/dto/constants/select-fields.const.ts
@@ -48,7 +48,6 @@ export class SelectFields {
       learningGoals: true,
       areasOfInterest: true,
       preferredSessionType: true,
-      availability: true,
       updatedAt: true,
       user: { select: this.getUserCredentialsSelect() },
       updatedBy: { select: { id: true, firstName: true, lastName: true } }

--- a/lib/models/src/lib/dto/constants/user-profile-validator.const.ts
+++ b/lib/models/src/lib/dto/constants/user-profile-validator.const.ts
@@ -7,7 +7,7 @@ export class UserProfileValidator {
     if (role === UserRole.Mentor) {
       return ['bio', 'skills', 'availability', 'updatedById'];
     }
-    return ['bio', 'learningGoals', 'areasOfInterest', 'preferredSessionType', 'availability', 'updatedById'];
+    return ['bio', 'learningGoals', 'areasOfInterest', 'preferredSessionType', 'updatedById'];
   }
 
   static validateRequiredFields(dto: UpdateMentorProfileDto | UpdateMenteeProfileDto, role: UserRole): string[] {
@@ -48,7 +48,6 @@ export class UserProfileValidator {
         learningGoals: currentDto.learningGoals,
         areasOfInterest: currentDto.areasOfInterest,
         preferredSessionType: currentDto.preferredSessionType,
-        availability: instanceToPlain(currentDto.availability),
         updatedById: currentDto.updatedById,
       };
     }

--- a/lib/models/src/lib/dto/users/update-user-profile.dto.ts
+++ b/lib/models/src/lib/dto/users/update-user-profile.dto.ts
@@ -114,19 +114,6 @@ export class UpdateMenteeProfileDto implements Partial<UpdateMenteeProfileInterf
   @IsOptional()
   preferredSessionType?: MenteePreferredSessionType;
 
-  @ApiPropertyOptional({ type: [UserAvailabilityDto] })
-  @Transform(({ value }) => {
-    if (typeof value === 'string') {
-      try { return JSON.parse(value); } catch { return value; }
-    }
-    return value;
-  })
-  @IsArray()
-  @ValidateNested({ each: true })
-  @Type(() => UserAvailabilityDto)
-  @IsOptional()
-  availability?: UserAvailabilityDto[];
-
   @ApiPropertyOptional()
   @IsUUID()
   @IsOptional()

--- a/lib/models/src/lib/interfaces/user/user.model.ts
+++ b/lib/models/src/lib/interfaces/user/user.model.ts
@@ -68,7 +68,6 @@ export interface MenteeProfileInterface {
   learningGoals: string[];
   areasOfInterest: string[];
   preferredSessionType: MenteePreferredSessionType;
-  availability: UserAvailabilityInterface[];
   user: UserInterface;
   updatedAt: string;
   updatedBy: UserFlatInterface;
@@ -83,7 +82,6 @@ export interface UpdateMenteeProfileInterface {
   learningGoals: string[];
   areasOfInterest: string[];
   preferredSessionType: MenteePreferredSessionType;
-  availability: UserAvailabilityInterface[];
   updatedById: string;
 }
 


### PR DESCRIPTION
# Changes #219 

Removes the availability field from the mentee profile entirely, as mentees do not manage their own schedule — only mentors do.

  Changes:
  - DTO — Removed availability field from UpdateMenteeProfileDto
  - Interfaces — Removed availability from MenteeProfileInterface and UpdateMenteeProfileInterface
  - SelectFields — Removed availability from getMenteeProfileSelect()
  - UserProfileValidator — Removed availability from mentee required fields and from buildProfilePayload() mentee branch
  - user.service.ts — Removed normalizeAvailability helper and availability from the mentee upsert payload
  - Prisma schema — Dropped availability Json column from MenteeProfile model
  - Migration — ALTER TABLE "mentee_profiles" DROP COLUMN "availability"