### PR TITLE
fix: enhance user profile retrieval and validation for mentees and mentors (#221)

### DIFF
--- a/apps/api/src/app/user/user.service.ts
+++ b/apps/api/src/app/user/user.service.ts
@@ -58,10 +58,10 @@ export class UserService {
   // ====================================================
 
   async getUserProfileById(
-    userId: string, 
-    ipAddress: string, 
+    userId: string,
+    ipAddress: string,
     userAgent: string
-  ): Promise<ResponseDto> { 
+  ): Promise<ResponseDto> {
     try {
       const user = await this.prisma.db.user.findUnique({
         where: { id: userId },
@@ -89,6 +89,22 @@ export class UserService {
         };
       }
 
+      // Fetch role-specific profile and embed it alongside user credentials
+      let responseData: Record<string, unknown> = { ...user };
+      if (user.role === UserRole.Mentee) {
+        const menteeProfile = await this.prisma.db.menteeProfile.findUnique({
+          where: { userId },
+          select: SelectFields.getMenteeProfileOnlySelect(),
+        });
+        responseData = { ...user, menteeProfile };
+      } else if (user.role === UserRole.Mentor) {
+        const mentorProfile = await this.prisma.db.mentorProfile.findUnique({
+          where: { userId },
+          select: SelectFields.getMentorProfileOnlySelect(),
+        });
+        responseData = { ...user, mentorProfile };
+      }
+
       await this.prisma.db.logs.create({
         data: {
           actionType: LogsActionType.Read,
@@ -105,7 +121,7 @@ export class UserService {
         status: ResponseStatus.Success,
         statusCode: API_RESPONSE.SUCCESS.GET_USER_PROFILE.code,
         message: API_RESPONSE.SUCCESS.GET_USER_PROFILE.message,
-        data: user,
+        data: responseData,
       };
     } catch (error) {
       const err = error instanceof Error ? error : new Error(String(error));
@@ -651,7 +667,7 @@ export class UserService {
       let profileResponse: Record<string, unknown> | null = null;
 
       if (role === UserRole.Mentor) {
-        const payload = UserProfileValidator.buildProfilePayload(effectiveDto, role, isProfileComplete);
+        const payload = UserProfileValidator.buildProfilePayload(effectiveDto, role);
         await this.prisma.db.$transaction(async (tx) => {
           profileResponse = await tx.mentorProfile.upsert({
             where: { userId },

--- a/lib/models/src/lib/dto/constants/select-fields.const.ts
+++ b/lib/models/src/lib/dto/constants/select-fields.const.ts
@@ -81,6 +81,35 @@ export class SelectFields {
     }
   }
 
+  static getMenteeProfileOnlySelect() {
+    return {
+      id: true,
+      bio: true,
+      learningGoals: true,
+      areasOfInterest: true,
+      preferredSessionType: true,
+      availability: true,
+      updatedAt: true,
+      updatedBy: { select: { id: true, firstName: true, lastName: true } },
+    };
+  }
+
+  static getMentorProfileOnlySelect() {
+    return {
+      id: true,
+      title: true,
+      areasOfExpertise: true,
+      yearsOfExperience: true,
+      linkedInUrl: true,
+      bio: true,
+      skills: true,
+      sessionRate: true,
+      availability: true,
+      updatedAt: true,
+      updatedBy: { select: { id: true, firstName: true, lastName: true } },
+    };
+  }
+
   static getMentorSearchSelect() {
     return {
       id: true,

--- a/lib/models/src/lib/dto/constants/user-profile-validator.const.ts
+++ b/lib/models/src/lib/dto/constants/user-profile-validator.const.ts
@@ -27,19 +27,17 @@ export class UserProfileValidator {
     }
   }
 
-  static buildProfilePayload(dto: UpdateMenteeProfileDto | UpdateMentorProfileDto, role: UserRole, isProfileComplete: boolean) {
+  static buildProfilePayload(dto: UpdateMenteeProfileDto | UpdateMentorProfileDto, role: UserRole) {
     if (role === UserRole.Mentor) {
       const currentDto = dto as UpdateMentorProfileDto;
       return {
         bio: currentDto.bio,
+        areasOfExpertise: currentDto.areasOfExpertise,
+        yearsOfExperience: currentDto.yearsOfExperience,
         skills: currentDto.skills,
         sessionRate: currentDto.sessionRate,
         availability: instanceToPlain(currentDto.availability),
         updatedById: currentDto.updatedById,
-        ...(isProfileComplete && {
-          areasOfExpertise: currentDto.areasOfExpertise,
-          yearsOfExperience: currentDto.yearsOfExperience,
-        }),
       };
     } else {
       const currentDto = dto as UpdateMenteeProfileDto;


### PR DESCRIPTION
# Changes #221 

### Updates

#### `GET /user/:userId/profile` now returns role-specific profile data

Previously, the endpoint only returned user credential fields. It now embeds the corresponding role-based profile alongside the user object:

* `menteeProfile` for mentees
* `mentorProfile` for mentors

This allows the frontend to access complete profile information directly from a single response.

#### Mentor setup now correctly saves `areasOfExpertise` and `yearsOfExperience`

`buildProfilePayload()` was previously gating these fields behind `isProfileComplete`, causing them to be silently excluded during the initial mentor profile setup.

Removed the guard so these fields are now consistently persisted on first submission and subsequent updates.

#### Added profile-only select helpers in `SelectFields`

Introduced:

* `getMenteeProfileOnlySelect()`
* `getMentorProfileOnlySelect()`

These selectors exclude nested user relations and are used when embedding role-specific profile data into the user profile response.

### Known Follow-up (Not in Scope)

* `profile-settings.page.ts` (`/settings/profile`) still needs a frontend update to consume the new response structure:

  * `profileData.menteeProfile.*`
  * `profileData.mentorProfile.*`
