### PR TITLE
fix: resolve build error due to removed 'availability'

### DIFF
--- a/apps/web/src/app/core/profile/profile.service.ts
+++ b/apps/web/src/app/core/profile/profile.service.ts
@@ -91,10 +91,6 @@ export class ProfileService {
     this.appendArrayField(formData, 'areasOfInterest', data.areasOfInterest);
     this.appendFieldIfPresent(formData, 'preferredSessionType', data.preferredSessionType);
 
-    if (data.availability) {
-      formData.append('availability', JSON.stringify(data.availability));
-    }
-
     formData.append('updatedById', userId);
 
     if (avatarFile) {


### PR DESCRIPTION
- The mentee form builder in profile.service.ts still had mentor-style availability handling copied over.
- Removed that block from buildMenteeProfileFormData. 