### PR TITLE
[249] Remove price filters in Find Mentors

### DIFF
--- a/apps/web/src/app/features/mentee/components/mentor-search/mentor-search.html
+++ b/apps/web/src/app/features/mentee/components/mentor-search/mentor-search.html
@@ -191,8 +191,9 @@
 
         </div>
 
-        <div class="mt-4 grid grid-cols-1 gap-4 lg:grid-cols-[minmax(0,1fr)_minmax(0,1fr)_minmax(0,1fr)_minmax(0,1fr)_3.5rem]">
-          <div class="relative">
+        <div class="mt-4 flex justify-center">
+          <div class="grid w-full grid-cols-1 gap-4 sm:grid-cols-[minmax(0,20rem)_minmax(0,20rem)_3.5rem] lg:w-auto">
+            <div class="relative">
             <p class="mb-1.5 text-[11px] font-bold uppercase tracking-[0.14em] text-slate-400">Language</p>
             <button
               type="button"
@@ -240,7 +241,7 @@
             }
           </div>
 
-          <div class="relative">
+            <div class="relative">
             <p class="mb-1.5 flex items-center gap-2 text-[11px] font-bold uppercase tracking-[0.14em] text-slate-400">
               Rating
             </p>
@@ -281,38 +282,17 @@
             }
           </div>
 
-          <div>
-            <p class="mb-1.5 text-[11px] font-bold uppercase tracking-[0.14em] text-slate-400">Min Price</p>
-            <input
-              type="number"
-              min="0"
-              formControlName="minSessionRate"
-              placeholder="P0"
-              class="block min-h-11 w-full rounded-xl border-0 bg-violet-50 px-4 text-sm font-semibold text-slate-600 outline-none placeholder:text-slate-400 focus:bg-violet-50 focus:ring-2 focus:ring-blue-200"
-            />
+            <button
+              type="button"
+              (click)="resetFilters()"
+              [disabled]="activeFilterCount() === 0"
+              class="inline-flex h-11 w-11 self-end items-center justify-center rounded-xl bg-blue-950 text-white shadow-[0_12px_24px_rgba(30,64,175,0.22)] transition hover:bg-blue-900 disabled:cursor-not-allowed disabled:bg-slate-200 disabled:text-slate-400 disabled:shadow-none"
+              aria-label="Clear filters"
+              title="Clear filters"
+            >
+              <app-icon name="filter" class="h-5 w-5" />
+            </button>
           </div>
-
-          <div>
-            <p class="mb-1.5 text-[11px] font-bold uppercase tracking-[0.14em] text-slate-400">Max Price</p>
-            <input
-              type="number"
-              min="0"
-              formControlName="maxSessionRate"
-              placeholder="P200"
-              class="block min-h-11 w-full rounded-xl border-0 bg-violet-50 px-4 text-sm font-semibold text-slate-600 outline-none placeholder:text-slate-400 focus:bg-violet-50 focus:ring-2 focus:ring-blue-200"
-            />
-          </div>
-
-          <button
-            type="button"
-            (click)="resetFilters()"
-            [disabled]="activeFilterCount() === 0"
-            class="self-end inline-flex min-h-11 items-center justify-center rounded-xl bg-blue-950 px-4 text-white shadow-[0_12px_24px_rgba(30,64,175,0.22)] transition hover:bg-blue-900 disabled:cursor-not-allowed disabled:bg-slate-200 disabled:text-slate-400 disabled:shadow-none"
-            aria-label="Clear filters"
-            title="Clear filters"
-          >
-            <app-icon name="filter" class="h-5 w-5" />
-          </button>
         </div>
       </div>
     </div>

--- a/apps/web/src/app/features/mentee/components/mentor-search/mentor-search.ts
+++ b/apps/web/src/app/features/mentee/components/mentor-search/mentor-search.ts
@@ -33,8 +33,6 @@ export class MentorSearch {
     name: '',
     availabilityDay: null,
     language: '',
-    minSessionRate: null,
-    maxSessionRate: null,
     minYearsExperience: null,
     maxYearsExperience: null,
     minRating: null,
@@ -52,8 +50,6 @@ export class MentorSearch {
     name: [''],
     availabilityDay: [null as AvailabilityOption | null],
     language: [''],
-    minSessionRate: [null as number | null],
-    maxSessionRate: [null as number | null],
     minYearsExperience: [null as number | null],
     maxYearsExperience: [null as number | null],
     minRating: [null as number | null],
@@ -111,8 +107,6 @@ export class MentorSearch {
       this.selectedExpertise().length > 0,
       value.availabilityDay != null,
       !!value.language?.trim(),
-      value.minSessionRate != null,
-      value.maxSessionRate != null,
       value.minYearsExperience != null,
       value.maxYearsExperience != null,
       value.minRating != null,
@@ -233,8 +227,6 @@ export class MentorSearch {
       name: formValue.name ?? null,
       availabilityDay: formValue.availabilityDay ?? null,
       language: formValue.language ?? null,
-      minSessionRate: this.getNumberOrNull(formValue.minSessionRate),
-      maxSessionRate: this.getNumberOrNull(formValue.maxSessionRate),
       minYearsExperience: this.getNumberOrNull(formValue.minYearsExperience),
       maxYearsExperience: this.getNumberOrNull(formValue.maxYearsExperience),
       minRating: this.getNumberOrNull(formValue.minRating),
@@ -254,8 +246,6 @@ export class MentorSearch {
       expertise: filters.expertise.length ? filters.expertise.join(',') : null,
       availabilityDay: filters.availabilityDay ?? null,
       language: filters.language || null,
-      minSessionRate: filters.minSessionRate ?? null,
-      maxSessionRate: filters.maxSessionRate ?? null,
       minYearsExperience: filters.minYearsExperience ?? null,
       maxYearsExperience: filters.maxYearsExperience ?? null,
       minRating: filters.minRating ?? null,
@@ -280,9 +270,6 @@ export class MentorSearch {
         params['availabilityDay'] as AvailabilityOption
       );
     }
-
-    this.setNumberFilterFromUrl(params, 'minSessionRate');
-    this.setNumberFilterFromUrl(params, 'maxSessionRate');
     this.setNumberFilterFromUrl(params, 'minYearsExperience');
     this.setNumberFilterFromUrl(params, 'maxYearsExperience');
     this.setNumberFilterFromUrl(params, 'minRating');
@@ -298,8 +285,6 @@ export class MentorSearch {
   private setNumberFilterFromUrl(
     params: Record<string, string>,
     controlName:
-      | 'minSessionRate'
-      | 'maxSessionRate'
       | 'minYearsExperience'
       | 'maxYearsExperience'
       | 'minRating'

--- a/apps/web/src/app/features/mentee/pages/mentee-find-mentors-page/mentee-find-mentors.page.ts
+++ b/apps/web/src/app/features/mentee/pages/mentee-find-mentors-page/mentee-find-mentors.page.ts
@@ -95,12 +95,6 @@ export class MenteeFindMentorsPage {
           : null,
       language:
         typeof params['language'] === 'string' ? params['language'] : null,
-      minSessionRate: this.parseOptionalPositiveNumber(
-        params['minSessionRate']
-      ),
-      maxSessionRate: this.parseOptionalPositiveNumber(
-        params['maxSessionRate']
-      ),
       minYearsExperience: this.parseOptionalPositiveNumber(
         params['minYearsExperience']
       ),

--- a/apps/web/src/app/features/mentee/services/mentee-search-mentor.service.ts
+++ b/apps/web/src/app/features/mentee/services/mentee-search-mentor.service.ts
@@ -42,8 +42,6 @@ export class MenteeSearchMentorService {
       ...(filters.expertise.length ? { expertise: filters.expertise.join(',') } : {}),
       ...(filters.availabilityDay != null ? { availabilityDay: filters.availabilityDay } : {}),
       ...(filters.language != null ? { language: filters.language } : {}),
-      ...(filters.minSessionRate != null ? { minSessionRate: filters.minSessionRate } : {}),
-      ...(filters.maxSessionRate != null ? { maxSessionRate: filters.maxSessionRate } : {}),
       ...(filters.minYearsExperience != null ? { minYearsExperience: filters.minYearsExperience } : {}),
       ...(filters.maxYearsExperience != null ? { maxYearsExperience: filters.maxYearsExperience } : {}),
       // ...(filters.minRating != null ? { minRating: filters.minRating } : {}), // PENDING BACKEND

--- a/lib/models/src/lib/interfaces/search/search.model.ts
+++ b/lib/models/src/lib/interfaces/search/search.model.ts
@@ -118,10 +118,7 @@ export interface MentorSearchFilter {
   page: number;
   limit: number;
   availabilityDay: AvailabilityOption | null;
-
   language: string | null;
-  minSessionRate: number | null;
-  maxSessionRate: number | null;
   minYearsExperience: number | null;
   maxYearsExperience: number | null;
   minRating: number | null;        // PENDING BACKEND


### PR DESCRIPTION
## Bug Ticket
- #249 Temporarily hide Price indicated in Finding a Mentor (Phase 1)

## Commit 
- [fix: remove find mentors price filters](https://github.com/Angular-PH-X-GuroKonekt-PH/gurokonekt-monorepo/commit/d7f34ec3872656e4a0321fe958f4d3827855ac8f)
## Changes

- Removed Min Price and Max Price filters from the Find Mentors page.
- Removed price filter form controls from the mentor search component.
- Removed price query param handling from the Find Mentors search flow.
- Stopped sending session rate filters to the mentor search API.
- Adjusted the remaining filter layout after removing the price fields.