### PR TITLE
fix: update email placeholder in login form

### DIFF
--- a/apps/admin-portal/src/app/core/auth/pages/login-page/login.page.html
+++ b/apps/admin-portal/src/app/core/auth/pages/login-page/login.page.html
@@ -19,7 +19,7 @@
           name="email"
           required
           class="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
-          placeholder="admin@gurokonekt.ph"
+          placeholder="your.email@example.com"
         />
       </div>
 


### PR DESCRIPTION
Changes:
  - Updated email input placeholder on the Admin Portal login page from
  admin@gurokonekt.ph to your.email@example.com as specified in issue #277.